### PR TITLE
chore: make libp2p-crypto a dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "buffer": "^6.0.3",
     "chai": "^4.3.4",
     "events": "^3.3.0",
+    "libp2p-crypto": "^0.19.7",
     "microtime": "^3.0.0",
     "mocha": "^9.0.2",
     "sinon": "^11.1.1"
@@ -56,7 +57,6 @@
     "it-pair": "^1.0.0",
     "it-pb-rpc": "^0.1.11",
     "it-pipe": "^1.1.0",
-    "libp2p-crypto": "^0.19.7",
     "peer-id": "^0.15.3",
     "protobufjs": "^6.11.2",
     "uint8arrays": "^3.0.0"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import { SHA256 } from '@stablelib/sha256'
 import * as x25519 from '@stablelib/x25519'
 import { Buffer } from 'buffer'
 import PeerId from 'peer-id'
-import { keys } from 'libp2p-crypto'
 import { KeyPair } from './@types/libp2p'
 import { bytes, bytes32 } from './@types/basic'
 import { Hkdf, INoisePayload } from './@types/handshake'
@@ -92,13 +91,13 @@ export async function verifySignedPayload (
   }
   const generatedPayload = getHandshakePayload(noiseStaticKey)
   // Unmarshaling from PublicKey protobuf
-  const publicKey = keys.unmarshalPublicKey(identityKey)
+  const peerId = await PeerId.createFromPubKey(identityKey)
   // TODO remove this after libp2p-crypto ships proper types
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  if (!payload.identitySig || !publicKey.verify(generatedPayload, Buffer.from(payload.identitySig))) {
+  if (!payload.identitySig || !peerId.pubKey.verify(generatedPayload, Buffer.from(payload.identitySig))) {
     throw new Error("Static key doesn't match to peer that signed payload!")
   }
-  return await PeerId.createFromPubKey(identityKey)
+  return peerId
 }
 
 export function getHkdf (ck: bytes32, ikm: bytes): Hkdf {


### PR DESCRIPTION
It's only used to verify incoming message payloads but the `pubKey` property on `PeerId` can do that.