### PR TITLE
fix: write handshake nonce correctly

### DIFF
--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -60,7 +60,7 @@ export abstract class AbstractHandshake {
   protected nonceToBytes (n: uint64): bytes {
     // Even though we're treating the nonce as 8 bytes, RFC7539 specifies 12 bytes for a nonce.
     const nonce = new Uint8Array(12)
-    new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength).setUint32(n, 4, true)
+    new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength).setUint32(4, n, true)
 
     return nonce
   }


### PR DESCRIPTION
The `value` and `offset` args to `Buffer.writeUInt32LE` vs `DataView.setUint32` are the other way round.

Fixes a bug introduced in #125 where we were using the nonce value as an offset and writing `4` rather than writing the nonce value at offset `4`.