### PR TITLE
fix: access node process object via globalThis

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const NOISE_MSG_MAX_LENGTH_BYTES = 65535
 export const NOISE_MSG_MAX_LENGTH_BYTES_WITHOUT_TAG = NOISE_MSG_MAX_LENGTH_BYTES - 16
 
-export const DUMP_SESSION_KEYS = process.env.DUMP_SESSION_KEYS
+export const DUMP_SESSION_KEYS = Boolean(globalThis.process?.env?.DUMP_SESSION_KEYS)


### PR DESCRIPTION
To allow use of noise in the browser with minimal bundling, access `process.env.FOO` via `globalThis` and with optional chaining.

Removes the need to use babel etc to transpile the code first.