### PR TITLE
fix: improve nonce performance

### DIFF
--- a/benchmarks/nonce.js
+++ b/benchmarks/nonce.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+import benchmark from 'benchmark'
+import { Nonce } from '../dist/src/@types/nonce.js'
+
+/**
+ * Using Nonce class is 150x faster than nonceToBytes
+ * nonceToBytes x 2.25 ops/sec ±1.41% (10 runs sampled)
+ * Nonce class x 341 ops/sec ±0.71% (87 runs sampled)
+ */
+function nonceToBytes (n) {
+  // Even though we're treating the nonce as 8 bytes, RFC7539 specifies 12 bytes for a nonce.
+  const nonce = new Uint8Array(12)
+  new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength).setUint32(4, n, true)
+  return nonce
+}
+const main = function () {
+  const bench1 = new benchmark('nonceToBytes', {
+    fn: function () {
+      for (let i = 1e6; i < 2 * 1e6; i++) {
+        nonceToBytes(i)
+      }
+    }
+  })
+    .on('complete', function (stats) {
+      console.log(String(stats.currentTarget))
+    })
+
+  bench1.run()
+
+  const bench2 = new benchmark('Nonce class', {
+    fn: function () {
+      const nonce = new Nonce(1e6)
+      for (let i = 1e6; i < 2 * 1e6; i++) {
+        nonce.increase()
+      }
+    }
+  })
+    .on('complete', function (stats) {
+      console.log(String(stats.currentTarget))
+    })
+
+  bench2.run()
+}
+
+main()

--- a/benchmarks/nonce.js
+++ b/benchmarks/nonce.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import benchmark from 'benchmark'
-import { Nonce } from '../dist/src/@types/nonce.js'
+import { Nonce } from '../dist/src/nonce.js'
 
 /**
  * Using Nonce class is 150x faster than nonceToBytes

--- a/benchmarks/nonce.js
+++ b/benchmarks/nonce.js
@@ -31,7 +31,7 @@ const main = function () {
     fn: function () {
       const nonce = new Nonce(1e6)
       for (let i = 1e6; i < 2 * 1e6; i++) {
-        nonce.increase()
+        nonce.increment()
       }
     }
   })

--- a/src/@types/handshake.ts
+++ b/src/@types/handshake.ts
@@ -1,5 +1,6 @@
 import type { bytes, bytes32, uint64 } from './basic.js'
 import type { KeyPair } from './libp2p.js'
+import type { Nonce } from './nonce.js'
 
 export type Hkdf = [bytes, bytes, bytes]
 
@@ -11,9 +12,9 @@ export interface MessageBuffer {
 
 export interface CipherState {
   k: bytes32
-  // For performance reasons, the nonce is represented as a JS `number`
+  // For performance reasons, the nonce is represented as a Nonce object
   // The nonce is treated as a uint64, even though the underlying `number` only has 52 safely-available bits.
-  n: uint64
+  n: Nonce
 }
 
 export interface SymmetricState {

--- a/src/@types/handshake.ts
+++ b/src/@types/handshake.ts
@@ -1,6 +1,6 @@
 import type { bytes, bytes32, uint64 } from './basic.js'
 import type { KeyPair } from './libp2p.js'
-import type { Nonce } from './nonce.js'
+import type { Nonce } from '../nonce.js'
 
 export type Hkdf = [bytes, bytes, bytes]
 

--- a/src/@types/nonce.ts
+++ b/src/@types/nonce.ts
@@ -1,0 +1,32 @@
+import type { bytes, uint64 } from './basic'
+
+/**
+ * The nonce is an uint that's increased over time.
+ * Maintaining different representations help improve performance.
+ */
+export class Nonce {
+  private n: uint64
+  private readonly bytes: bytes
+  private readonly view: DataView
+
+  constructor (n: uint64) {
+    this.n = n
+    this.bytes = new Uint8Array(12)
+    this.view = new DataView(this.bytes.buffer, this.bytes.byteOffset, this.bytes.byteLength)
+    this.view.setUint32(4, n, true)
+  }
+
+  increase (): void {
+    this.n++
+    // Even though we're treating the nonce as 8 bytes, RFC7539 specifies 12 bytes for a nonce.
+    this.view.setUint32(4, this.n, true)
+  }
+
+  getBytes (): bytes {
+    return this.bytes
+  }
+
+  getUint64 (): uint64 {
+    return this.n
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -43,8 +43,8 @@ export function logRemoteEphemeralKey (re: Uint8Array): void {
 
 export function logCipherState (session: NoiseSession): void {
   if (session.cs1 && session.cs2) {
-    keyLogger(`CIPHER_STATE_1 ${session.cs1.n} ${uint8ArrayToString(session.cs1.k, 'hex')}`)
-    keyLogger(`CIPHER_STATE_2 ${session.cs2.n} ${uint8ArrayToString(session.cs2.k, 'hex')}`)
+    keyLogger(`CIPHER_STATE_1 ${session.cs1.n.getUint64()} ${uint8ArrayToString(session.cs1.k, 'hex')}`)
+    keyLogger(`CIPHER_STATE_2 ${session.cs2.n.getUint64()} ${uint8ArrayToString(session.cs2.k, 'hex')}`)
   } else {
     keyLogger('Missing cipher state.')
   }

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -2,11 +2,12 @@ import type { bytes, uint64 } from './@types/basic'
 
 export const MIN_NONCE = 0
 // For performance reasons, the nonce is represented as a JS `number`
-// JS `number` can only safely represent integers up to 2 ** 53 - 1
+// Although JS `number` can safely represent integers up to 2 ** 53 - 1, we choose to only use
+// 4 bytes to store the data for performance reason.
 // This is a slight deviation from the noise spec, which describes the max nonce as 2 ** 64 - 2
 // The effect is that this implementation will need a new handshake to be performed after fewer messages are exchanged than other implementations with full uint64 nonces.
-// 2 ** 53 - 1 is still a large number of messages, so the practical effect of this is negligible.
-export const MAX_NONCE = Number.MAX_SAFE_INTEGER
+// this MAX_NONCE is still a large number of messages, so the practical effect of this is negligible.
+export const MAX_NONCE = 0xffffffff
 
 const ERR_MAX_NONCE = 'Cipherstate has reached maximum n, a new handshake must be performed'
 

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -1,4 +1,4 @@
-import type { bytes, uint64 } from './basic'
+import type { bytes, uint64 } from './@types/basic'
 
 /**
  * The nonce is an uint that's increased over time.

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -1,5 +1,15 @@
 import type { bytes, uint64 } from './@types/basic'
 
+export const MIN_NONCE = 0
+// For performance reasons, the nonce is represented as a JS `number`
+// JS `number` can only safely represent integers up to 2 ** 53 - 1
+// This is a slight deviation from the noise spec, which describes the max nonce as 2 ** 64 - 2
+// The effect is that this implementation will need a new handshake to be performed after fewer messages are exchanged than other implementations with full uint64 nonces.
+// 2 ** 53 - 1 is still a large number of messages, so the practical effect of this is negligible.
+export const MAX_NONCE = Number.MAX_SAFE_INTEGER
+
+const ERR_MAX_NONCE = 'Cipherstate has reached maximum n, a new handshake must be performed'
+
 /**
  * The nonce is an uint that's increased over time.
  * Maintaining different representations help improve performance.
@@ -9,14 +19,14 @@ export class Nonce {
   private readonly bytes: bytes
   private readonly view: DataView
 
-  constructor (n: uint64) {
+  constructor (n = MIN_NONCE) {
     this.n = n
     this.bytes = new Uint8Array(12)
     this.view = new DataView(this.bytes.buffer, this.bytes.byteOffset, this.bytes.byteLength)
     this.view.setUint32(4, n, true)
   }
 
-  increase (): void {
+  increment (): void {
     this.n++
     // Even though we're treating the nonce as 8 bytes, RFC7539 specifies 12 bytes for a nonce.
     this.view.setUint32(4, this.n, true)
@@ -28,5 +38,11 @@ export class Nonce {
 
   getUint64 (): uint64 {
     return this.n
+  }
+
+  assertValue (): void {
+    if (this.n > MAX_NONCE) {
+      throw new Error(ERR_MAX_NONCE)
+    }
   }
 }


### PR DESCRIPTION
**Motivation**
- There's a performance issue of `nonceToBytes()` as shown in https://github.com/ChainSafe/lodestar/issues/4140#issuecomment-1161174710
- Maintaining both Uint8Array and DataView and uint64 help improving nonce significantly

**Description**
- New `Nonce` class containing above data with `getUint64()`, `getBytes()` and `increase()` method
- New benchmark shows it's 150x faster