### PR TITLE
chore: clean up logic

### DIFF
--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -73,7 +73,7 @@ export class IKHandshake implements IHandshake {
           throw new Error('ik handshake stage 0 decryption validation fail')
         }
         logger('IK Stage 0 - Responder got message, going to verify payload.')
-        const decodedPayload = await decodePayload(plaintext)
+        const decodedPayload = decodePayload(plaintext)
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload)
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer)
         this.setRemoteEarlyData(decodedPayload.data)
@@ -99,7 +99,7 @@ export class IKHandshake implements IHandshake {
         if (!valid) {
           throw new Error('ik stage 1 decryption validation fail')
         }
-        const decodedPayload = await decodePayload(plaintext)
+        const decodedPayload = decodePayload(plaintext)
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload)
         await verifySignedPayload(receivedMessageBuffer.ns.slice(0, 32), decodedPayload, this.remotePeer)
         this.setRemoteEarlyData(decodedPayload.data)

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -69,7 +69,7 @@ export class XXFallbackHandshake extends XXHandshake {
 
       logger("Initiator going to check remote's signature...")
       try {
-        const decodedPayload = await decodePayload(plaintext)
+        const decodedPayload = decodePayload(plaintext)
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload)
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer)
         this.setRemoteEarlyData(decodedPayload.data)

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -94,9 +94,9 @@ export class XXHandshake implements IHandshake {
 
       logger("Initiator going to check remote's signature...")
       try {
-        const decodedPayload = await decodePayload(plaintext)
+        const decodedPayload = decodePayload(plaintext)
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload)
-        this.remotePeer = await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer)
+        await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer)
         this.setRemoteEarlyData(decodedPayload.data)
       } catch (e) {
         const err = e as Error
@@ -129,7 +129,7 @@ export class XXHandshake implements IHandshake {
       logger('Stage 2 - Responder received the message, finished handshake.')
 
       try {
-        const decodedPayload = await decodePayload(plaintext)
+        const decodedPayload = decodePayload(plaintext)
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload)
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer)
         this.setRemoteEarlyData(decodedPayload.data)

--- a/src/handshakes/ik.ts
+++ b/src/handshakes/ik.ts
@@ -108,7 +108,7 @@ export class IK extends AbstractHandshake {
     this.mixHash(hs.ss, hs.re)
     this.mixKey(hs.ss, this.dh(hs.s.privateKey, hs.re))
     const { plaintext: ns, valid: valid1 } = this.decryptAndHash(hs.ss, message.ns)
-    if (valid1 && ns.length === 32 && isValidPublicKey(ns)) {
+    if (valid1 && isValidPublicKey(ns)) {
       hs.rs = ns
     }
     this.mixKey(hs.ss, this.dh(hs.s.privateKey, hs.rs))

--- a/src/handshakes/xx.ts
+++ b/src/handshakes/xx.ts
@@ -87,7 +87,7 @@ export class XX extends AbstractHandshake {
     }
     this.mixKey(hs.ss, this.dh(hs.e.privateKey, hs.re))
     const { plaintext: ns, valid: valid1 } = this.decryptAndHash(hs.ss, message.ns)
-    if (valid1 && ns.length === 32 && isValidPublicKey(ns)) {
+    if (valid1 && isValidPublicKey(ns)) {
       hs.rs = ns
     }
     this.mixKey(hs.ss, this.dh(hs.e.privateKey, hs.rs))
@@ -97,7 +97,7 @@ export class XX extends AbstractHandshake {
 
   private readMessageC (hs: HandshakeState, message: MessageBuffer): {h: bytes, plaintext: bytes, valid: boolean, cs1: CipherState, cs2: CipherState} {
     const { plaintext: ns, valid: valid1 } = this.decryptAndHash(hs.ss, message.ns)
-    if (valid1 && ns.length === 32 && isValidPublicKey(ns)) {
+    if (valid1 && isValidPublicKey(ns)) {
       hs.rs = ns
     }
     if (!hs.e) {


### PR DESCRIPTION
- decodePayload is synchronous
- remove isValidPeerId - only decode peer id once
- don't use the return value of verifySignedPayload anywhere
- remove duplicate length check, use isValidPublicKey