### PR TITLE
chore: fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@libp2p/peer-id-factory": "^1.0.8",
     "aegir": "^37.3.0",
     "benchmark": "^2.1.4",
+    "iso-random-stream": "^2.0.2",
     "mkdirp": "^1.0.4",
     "protons": "^4.0.0",
     "sinon": "^14.0.0"

--- a/test/noise.spec.ts
+++ b/test/noise.spec.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from '@libp2p/crypto'
+import { randomBytes } from 'iso-random-stream'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { Buffer } from 'buffer'
 import { assert, expect } from 'aegir/chai'


### PR DESCRIPTION
The latest crypto release removed the ability to generate random data larger than 64kb so use iso-random-stream directly instead.