### PR TITLE
feat!: remove default instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,14 @@ Install with `yarn add @chainsafe/libp2p-noise` or `npm i @chainsafe/libp2p-nois
 Example of using default noise configuration and passing it to the libp2p config:
 
 ```js
-import {NOISE, Noise} from "@chainsafe/libp2p-noise"
+import {Noise} from "@chainsafe/libp2p-noise"
 
-
-//custom noise configuration, pass it instead of NOISE instance
+//custom noise configuration, pass it instead of `new Noise()`
 const noise = new Noise(privateKey, Buffer.alloc(x));
 
 const libp2p = new Libp2p({
    modules: {
-     connEncryption: [NOISE],
+     connEncryption: [new Noise()],
    },
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,3 @@
-import { Noise } from './noise.js'
-
 export * from './crypto.js'
 export * from './crypto/stablelib.js'
 export * from './noise.js'
-
-/**
- * Default configuration, it will generate new noise static key and enable noise pipes (IK handshake).
- */
-export const NOISE = new Noise()


### PR DESCRIPTION
In Cloudflare workers you cannot call some crypto functions outside of a request:

```
Error: Some functionality, such as asynchronous I/O (fetch, Cache API, KV), timeouts (setTimeout, setInterval), and generating random values (crypto.getRandomValues, crypto.subtle.generateKey), can only be performed while handling a request.
```

This error occurs when importing the module because a default instance is created up front (the `NOISE` export).

This PR removes the default `NOISE` export to allow folks to create an instance when needed.

BREAKING CHANGE: The default instance `NOISE` is not longer created or exported. Import `Noise` and use `new Noise()` in place of `NOISE`.

resolves https://github.com/ChainSafe/js-libp2p-noise/issues/180