### PR TITLE
fix: only increment nonce in valid decrypted msg

### DIFF
--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -23,7 +23,7 @@ export abstract class AbstractHandshake {
 
   public decryptWithAd (cs: CipherState, ad: Uint8Array, ciphertext: Uint8Array): {plaintext: bytes, valid: boolean} {
     const { plaintext, valid } = this.decrypt(cs.k, cs.n, ad, ciphertext)
-    cs.n.increment()
+    if (valid) cs.n.increment()
 
     return { plaintext, valid }
   }


### PR DESCRIPTION
resolves https://github.com/ChainSafe/js-libp2p-noise/issues/199

minimal fix

A bigger code change would involve `throw`ing at a lower level rather than pass `valid` boolean up (only to ultimately `throw` there)