### PR TITLE
feat: use allocUnsafe() where possible

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -3,14 +3,7 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 import type { bytes } from './@types/basic.js'
 import type { MessageBuffer } from './@types/handshake.js'
 import type { LengthDecoderFunction, LengthEncoderFunction } from 'it-length-prefixed'
-
-const allocUnsafe = (len: number): Uint8Array => {
-  if (globalThis.Buffer) {
-    return globalThis.Buffer.allocUnsafe(len)
-  }
-
-  return new Uint8Array(len)
-}
+import { allocUnsafe } from './utils.js'
 
 export const uint16BEEncode: LengthEncoderFunction = (value: number) => {
   const target = allocUnsafe(2)
@@ -52,7 +45,7 @@ export function decode0 (input: bytes): MessageBuffer {
   return {
     ne: input.subarray(0, 32),
     ciphertext: input.subarray(32, input.length),
-    ns: new Uint8Array(0)
+    ns: allocUnsafe(0)
   }
 }
 
@@ -74,7 +67,7 @@ export function decode2 (input: bytes): MessageBuffer {
   }
 
   return {
-    ne: new Uint8Array(0),
+    ne: allocUnsafe(0),
     ns: input.subarray(0, 48),
     ciphertext: input.subarray(48, input.length)
   }

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,9 +1,9 @@
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
+import { allocUnsafe } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 import type { bytes } from './@types/basic.js'
 import type { MessageBuffer } from './@types/handshake.js'
 import type { LengthDecoderFunction, LengthEncoderFunction } from 'it-length-prefixed'
-import { allocUnsafe } from './utils.js'
 
 export const uint16BEEncode: LengthEncoderFunction = (value: number) => {
   const target = allocUnsafe(2)

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -17,6 +17,7 @@ import {
   logCipherState
 } from './logger.js'
 import {
+  allocUnsafe,
   decodePayload,
   getPeerIdFromPayload,
   verifySignedPayload
@@ -55,7 +56,7 @@ export class XXHandshake implements IHandshake {
     }
     this.xx = handshake ?? new XX(crypto)
     this.session = this.xx.initSession(this.isInitiator, this.prologue, this.staticKeypair)
-    this.remoteEarlyData = new Uint8Array(0)
+    this.remoteEarlyData = allocUnsafe(0)
   }
 
   // stage 0
@@ -63,7 +64,7 @@ export class XXHandshake implements IHandshake {
     logLocalStaticKeys(this.session.hs.s)
     if (this.isInitiator) {
       logger('Stage 0 - Initiator starting to send first message.')
-      const messageBuffer = this.xx.sendMessage(this.session, new Uint8Array(0))
+      const messageBuffer = this.xx.sendMessage(this.session, allocUnsafe(0))
       this.connection.writeLP(encode0(messageBuffer))
       logger('Stage 0 - Initiator finished sending first message.')
       logLocalEphemeralKeys(this.session.hs.e)
@@ -144,13 +145,13 @@ export class XXHandshake implements IHandshake {
   public encrypt (plaintext: Uint8Array, session: NoiseSession): bytes {
     const cs = this.getCS(session)
 
-    return this.xx.encryptWithAd(cs, new Uint8Array(0), plaintext)
+    return this.xx.encryptWithAd(cs, allocUnsafe(0), plaintext)
   }
 
   public decrypt (ciphertext: Uint8Array, session: NoiseSession): {plaintext: bytes, valid: boolean} {
     const cs = this.getCS(session, false)
 
-    return this.xx.decryptWithAd(cs, new Uint8Array(0), ciphertext)
+    return this.xx.decryptWithAd(cs, allocUnsafe(0), ciphertext)
   }
 
   public getRemoteStaticKey (): bytes {

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -16,8 +16,8 @@ import {
   logRemoteStaticKey,
   logCipherState
 } from './logger.js'
+import { allocUnsafe } from 'uint8arrays/alloc'
 import {
-  allocUnsafe,
   decodePayload,
   getPeerIdFromPayload,
   verifySignedPayload

--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -6,7 +6,7 @@ import type { CipherState, MessageBuffer, SymmetricState } from '../@types/hands
 import type { ICryptoInterface } from '../crypto.js'
 import { logger } from '../logger.js'
 import { Nonce } from '../nonce.js'
-import { alloc, allocUnsafe } from '../utils.js'
+import { allocUnsafe, alloc } from 'uint8arrays/alloc'
 
 export abstract class AbstractHandshake {
   public crypto: ICryptoInterface

--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -6,6 +6,7 @@ import type { CipherState, MessageBuffer, SymmetricState } from '../@types/hands
 import type { ICryptoInterface } from '../crypto.js'
 import { logger } from '../logger.js'
 import { Nonce } from '../nonce.js'
+import { alloc, allocUnsafe } from '../utils.js'
 
 export abstract class AbstractHandshake {
   public crypto: ICryptoInterface
@@ -34,7 +35,7 @@ export abstract class AbstractHandshake {
   }
 
   protected createEmptyKey (): bytes32 {
-    return new Uint8Array(32)
+    return alloc(32)
   }
 
   protected isEmptyKey (k: bytes32): boolean {
@@ -72,7 +73,7 @@ export abstract class AbstractHandshake {
       }
     } else {
       return {
-        plaintext: new Uint8Array(0),
+        plaintext: allocUnsafe(0),
         valid: false
       }
     }
@@ -102,7 +103,7 @@ export abstract class AbstractHandshake {
     } catch (e) {
       const err = e as Error
       logger(err.message)
-      return new Uint8Array(32)
+      return alloc(32)
     }
   }
 
@@ -140,16 +141,16 @@ export abstract class AbstractHandshake {
 
   protected hashProtocolName (protocolName: Uint8Array): bytes32 {
     if (protocolName.length <= 32) {
-      const h = new Uint8Array(32)
+      const h = alloc(32)
       h.set(protocolName)
       return h
     } else {
-      return this.getHash(protocolName, new Uint8Array(0))
+      return this.getHash(protocolName, allocUnsafe(0))
     }
   }
 
   protected split (ss: SymmetricState): {cs1: CipherState, cs2: CipherState} {
-    const [tempk1, tempk2] = this.crypto.getHKDF(ss.ck, new Uint8Array(0))
+    const [tempk1, tempk2] = this.crypto.getHKDF(ss.ck, allocUnsafe(0))
     const cs1 = this.initializeKey(tempk1)
     const cs2 = this.initializeKey(tempk2)
 
@@ -157,14 +158,14 @@ export abstract class AbstractHandshake {
   }
 
   protected writeMessageRegular (cs: CipherState, payload: bytes): MessageBuffer {
-    const ciphertext = this.encryptWithAd(cs, new Uint8Array(0), payload)
+    const ciphertext = this.encryptWithAd(cs, allocUnsafe(0), payload)
     const ne = this.createEmptyKey()
-    const ns = new Uint8Array(0)
+    const ns = allocUnsafe(0)
 
     return { ne, ns, ciphertext }
   }
 
   protected readMessageRegular (cs: CipherState, message: MessageBuffer): {plaintext: bytes, valid: boolean} {
-    return this.decryptWithAd(cs, new Uint8Array(0), message.ciphertext)
+    return this.decryptWithAd(cs, allocUnsafe(0), message.ciphertext)
   }
 }

--- a/src/handshakes/xx.ts
+++ b/src/handshakes/xx.ts
@@ -1,6 +1,8 @@
 import type { bytes32, bytes } from '../@types/basic.js'
 import type { KeyPair } from '../@types/libp2p.js'
-import { allocUnsafe, isValidPublicKey, alloc } from '../utils.js'
+import { isValidPublicKey } from '../utils.js'
+import { allocUnsafe, alloc } from 'uint8arrays/alloc'
+
 import type { CipherState, HandshakeState, MessageBuffer, NoiseSession } from '../@types/handshake.js'
 import { AbstractHandshake } from './abstract-handshake.js'
 

--- a/src/handshakes/xx.ts
+++ b/src/handshakes/xx.ts
@@ -1,6 +1,6 @@
 import type { bytes32, bytes } from '../@types/basic.js'
 import type { KeyPair } from '../@types/libp2p.js'
-import { isValidPublicKey } from '../utils.js'
+import { allocUnsafe, isValidPublicKey, alloc } from '../utils.js'
 import type { CipherState, HandshakeState, MessageBuffer, NoiseSession } from '../@types/handshake.js'
 import { AbstractHandshake } from './abstract-handshake.js'
 
@@ -9,7 +9,7 @@ export class XX extends AbstractHandshake {
     const name = 'Noise_XX_25519_ChaChaPoly_SHA256'
     const ss = this.initializeSymmetric(name)
     this.mixHash(ss, prologue)
-    const re = new Uint8Array(32)
+    const re = alloc(32)
 
     return { ss, s, rs, psk, re }
   }
@@ -18,13 +18,13 @@ export class XX extends AbstractHandshake {
     const name = 'Noise_XX_25519_ChaChaPoly_SHA256'
     const ss = this.initializeSymmetric(name)
     this.mixHash(ss, prologue)
-    const re = new Uint8Array(32)
+    const re = alloc(32)
 
     return { ss, s, rs, psk, re }
   }
 
   private writeMessageA (hs: HandshakeState, payload: bytes, e?: KeyPair): MessageBuffer {
-    const ns = new Uint8Array(0)
+    const ns = allocUnsafe(0)
 
     if (e !== undefined) {
       hs.e = e
@@ -113,7 +113,7 @@ export class XX extends AbstractHandshake {
 
   public initSession (initiator: boolean, prologue: bytes32, s: KeyPair): NoiseSession {
     const psk = this.createEmptyKey()
-    const rs = new Uint8Array(32) // no static key yet
+    const rs = alloc(32) // no static key yet
     let hs
 
     if (initiator) {
@@ -164,7 +164,7 @@ export class XX extends AbstractHandshake {
   }
 
   public recvMessage (session: NoiseSession, message: MessageBuffer): {plaintext: bytes, valid: boolean} {
-    let plaintext: bytes = new Uint8Array(0)
+    let plaintext: bytes = allocUnsafe(0)
     let valid = false
     if (session.mc === 0) {
       ({ plaintext, valid } = this.readMessageA(session.hs, message))

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -14,7 +14,8 @@ import { stablelib } from './crypto/stablelib.js'
 import { decryptStream, encryptStream } from './crypto/streaming.js'
 import { uint16BEDecode, uint16BEEncode } from './encoder.js'
 import { XXHandshake } from './handshake-xx.js'
-import { allocUnsafe, getPayload } from './utils.js'
+import { allocUnsafe } from 'uint8arrays/alloc'
+import { getPayload } from './utils.js'
 
 interface HandshakeParams {
   connection: ProtobufStream

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -14,7 +14,7 @@ import { stablelib } from './crypto/stablelib.js'
 import { decryptStream, encryptStream } from './crypto/streaming.js'
 import { uint16BEDecode, uint16BEEncode } from './encoder.js'
 import { XXHandshake } from './handshake-xx.js'
-import { getPayload } from './utils.js'
+import { allocUnsafe, getPayload } from './utils.js'
 
 interface HandshakeParams {
   connection: ProtobufStream
@@ -36,7 +36,7 @@ export class Noise implements INoiseConnection {
    * @param {bytes} earlyData
    */
   constructor (staticNoiseKey?: bytes, earlyData?: bytes, crypto: ICryptoInterface = stablelib, prologueBytes?: Uint8Array) {
-    this.earlyData = earlyData ?? new Uint8Array(0)
+    this.earlyData = earlyData ?? allocUnsafe(0)
     this.crypto = crypto
 
     if (staticNoiseKey) {
@@ -45,7 +45,7 @@ export class Noise implements INoiseConnection {
     } else {
       this.staticKeys = this.crypto.generateX25519KeyPair()
     }
-    this.prologue = prologueBytes ?? new Uint8Array(0)
+    this.prologue = prologueBytes ?? allocUnsafe(0)
   }
 
   /**

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -1,5 +1,5 @@
 import type { bytes, uint64 } from './@types/basic'
-import { allocUnsafe } from './utils.js'
+import { allocUnsafe } from 'uint8arrays/alloc'
 
 export const MIN_NONCE = 0
 // For performance reasons, the nonce is represented as a JS `number`

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -1,4 +1,5 @@
 import type { bytes, uint64 } from './@types/basic'
+import { allocUnsafe } from './utils.js'
 
 export const MIN_NONCE = 0
 // For performance reasons, the nonce is represented as a JS `number`
@@ -22,7 +23,8 @@ export class Nonce {
 
   constructor (n = MIN_NONCE) {
     this.n = n
-    this.bytes = new Uint8Array(12)
+    this.bytes = allocUnsafe(12)
+    this.bytes.fill(0)
     this.view = new DataView(this.bytes.buffer, this.bytes.byteOffset, this.bytes.byteLength)
     this.view.setUint32(4, n, true)
   }

--- a/src/proto/payload.ts
+++ b/src/proto/payload.ts
@@ -4,7 +4,7 @@
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
-import { allocUnsafe } from '../utils.js'
+import { allocUnsafe } from 'uint8arrays/alloc'
 
 export namespace pb {
   export interface NoiseHandshakePayload {

--- a/src/proto/payload.ts
+++ b/src/proto/payload.ts
@@ -4,6 +4,7 @@
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import { allocUnsafe } from '../utils.js'
 
 export namespace pb {
   export interface NoiseHandshakePayload {
@@ -48,9 +49,9 @@ export namespace pb {
           }
         }, (reader, length) => {
           const obj: any = {
-            identityKey: new Uint8Array(0),
-            identitySig: new Uint8Array(0),
-            data: new Uint8Array(0)
+            identityKey: allocUnsafe(0),
+            identitySig: allocUnsafe(0),
+            data: allocUnsafe(0)
           }
 
           const end = length == null ? reader.len : reader.pos + length

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export async function getPayload (
   earlyData?: bytes
 ): Promise<bytes> {
   const signedPayload = await signPayload(localPeer, getHandshakePayload(staticPublicKey))
-  const earlyDataPayload = earlyData ?? new Uint8Array(0)
+  const earlyDataPayload = earlyData ?? allocUnsafe(0)
 
   if (localPeer.publicKey == null) {
     throw new Error('PublicKey was missing from local PeerId')
@@ -35,7 +35,7 @@ export function createHandshakePayload (
   return NoiseHandshakePayloadProto.encode({
     identityKey: libp2pPublicKey,
     identitySig: signedPayload,
-    data: earlyData ?? new Uint8Array(0)
+    data: earlyData ?? allocUnsafe(0)
   }).subarray()
 }
 
@@ -111,4 +111,29 @@ export function isValidPublicKey (pk: bytes): boolean {
   }
 
   return true
+}
+
+/**
+ * Returns a `Uint8Array` of the requested size. Referenced memory will
+ * be initialized to 0.
+ */
+export function alloc (size = 0): Uint8Array {
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.alloc(size)
+  }
+
+  return new Uint8Array(size)
+}
+
+/**
+ * Where possible returns a Uint8Array of the requested size that references
+ * uninitialized memory. Only use if you are certain you will immediately
+ * overwrite every value in the returned `Uint8Array`.
+ */
+export function allocUnsafe (len: number): Uint8Array {
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.allocUnsafe(len)
+  }
+
+  return new Uint8Array(len)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { unmarshalPublicKey, unmarshalPrivateKey } from '@libp2p/crypto/keys'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { peerIdFromKeys } from '@libp2p/peer-id'
+import { allocUnsafe } from 'uint8arrays/alloc'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { bytes } from './@types/basic.js'
@@ -111,29 +112,4 @@ export function isValidPublicKey (pk: bytes): boolean {
   }
 
   return true
-}
-
-/**
- * Returns a `Uint8Array` of the requested size. Referenced memory will
- * be initialized to 0.
- */
-export function alloc (size = 0): Uint8Array {
-  if (globalThis.Buffer) {
-    return globalThis.Buffer.alloc(size)
-  }
-
-  return new Uint8Array(size)
-}
-
-/**
- * Where possible returns a Uint8Array of the requested size that references
- * uninitialized memory. Only use if you are certain you will immediately
- * overwrite every value in the returned `Uint8Array`.
- */
-export function allocUnsafe (len: number): Uint8Array {
-  if (globalThis.Buffer) {
-    return globalThis.Buffer.allocUnsafe(len)
-  }
-
-  return new Uint8Array(len)
 }


### PR DESCRIPTION
**Motivation**
- allocUnsafe() is better in NodeJS environment
- there is an external memory spike issue in lodestar

**Description**
- Use `allocUnsafe` where possible