### PR TITLE
chore: relax semantic PR validation

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -17,9 +17,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           requireScope: false
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: false
           types: |
             fix
             feat
             chore
+            docs


### PR DESCRIPTION
With new GitHub features it is no longer necessary to validate this as you can set GitHub to prefer PR title in repository settings.