### PR TITLE
feat: reuse encrypted data to avoid memory allocation

### DIFF
--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -8,5 +8,5 @@ export interface IHandshake {
   remotePeer: PeerId
   remoteExtensions: NoiseExtensions
   encrypt: (plaintext: bytes, session: NoiseSession) => bytes
-  decrypt: (ciphertext: bytes, session: NoiseSession) => { plaintext: bytes, valid: boolean }
+  decrypt: (ciphertext: bytes, session: NoiseSession, dst?: Uint8Array) => { plaintext: bytes, valid: boolean }
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -12,5 +12,5 @@ export interface ICryptoInterface {
   generateX25519SharedKey: (privateKey: Uint8Array, publicKey: Uint8Array) => Uint8Array
 
   chaCha20Poly1305Encrypt: (plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32) => bytes
-  chaCha20Poly1305Decrypt: (ciphertext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32) => bytes | null
+  chaCha20Poly1305Decrypt: (ciphertext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32, dst?: Uint8Array) => bytes | null
 }

--- a/src/crypto/stablelib.ts
+++ b/src/crypto/stablelib.ts
@@ -52,9 +52,9 @@ export const stablelib: ICryptoInterface = {
     return ctx.seal(nonce, plaintext, ad)
   },
 
-  chaCha20Poly1305Decrypt (ciphertext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32): bytes | null {
+  chaCha20Poly1305Decrypt (ciphertext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32, dst?: Uint8Array): bytes | null {
     const ctx = new ChaCha20Poly1305(k)
 
-    return ctx.open(nonce, ciphertext, ad)
+    return ctx.open(nonce, ciphertext, ad, dst)
   }
 }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -147,10 +147,10 @@ export class XXHandshake implements IHandshake {
     return this.xx.encryptWithAd(cs, new Uint8Array(0), plaintext)
   }
 
-  public decrypt (ciphertext: Uint8Array, session: NoiseSession): { plaintext: bytes, valid: boolean } {
+  public decrypt (ciphertext: Uint8Array, session: NoiseSession, dst?: Uint8Array): { plaintext: bytes, valid: boolean } {
     const cs = this.getCS(session, false)
 
-    return this.xx.decryptWithAd(cs, new Uint8Array(0), ciphertext)
+    return this.xx.decryptWithAd(cs, new Uint8Array(0), ciphertext, dst)
   }
 
   public getRemoteStaticKey (): bytes {

--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -21,8 +21,8 @@ export abstract class AbstractHandshake {
     return e
   }
 
-  public decryptWithAd (cs: CipherState, ad: Uint8Array, ciphertext: Uint8Array): {plaintext: bytes, valid: boolean} {
-    const { plaintext, valid } = this.decrypt(cs.k, cs.n, ad, ciphertext)
+  public decryptWithAd (cs: CipherState, ad: Uint8Array, ciphertext: Uint8Array, dst?: Uint8Array): {plaintext: bytes, valid: boolean} {
+    const { plaintext, valid } = this.decrypt(cs.k, cs.n, ad, ciphertext, dst)
     if (valid) cs.n.increment()
 
     return { plaintext, valid }
@@ -60,10 +60,10 @@ export abstract class AbstractHandshake {
     return ciphertext
   }
 
-  protected decrypt (k: bytes32, n: Nonce, ad: bytes, ciphertext: bytes): {plaintext: bytes, valid: boolean} {
+  protected decrypt (k: bytes32, n: Nonce, ad: bytes, ciphertext: bytes, dst?: Uint8Array): {plaintext: bytes, valid: boolean} {
     n.assertValue()
 
-    const encryptedMessage = this.crypto.chaCha20Poly1305Decrypt(ciphertext, n.getBytes(), ad, k)
+    const encryptedMessage = this.crypto.chaCha20Poly1305Decrypt(ciphertext, n.getBytes(), ad, k, dst)
 
     if (encryptedMessage) {
       return {


### PR DESCRIPTION
**Motivation**
As tested in lodestar, memory allocation is expensive for `decrypt()` flow

<img width="812" alt="Screen Shot 2022-10-25 at 11 13 58" src="https://user-images.githubusercontent.com/10568965/197731910-7af72640-4840-4935-8f95-89f47d0caa3b.png">

**Description**
- Stablelib already supports option `dst?: Uint8Array` parameter in its chacha20poly1305 implementation, the new `as-chacha20poly1305` should follow the same interface
- When decrypting, reuse the same memory as encrypted message is not used after that