### PR TITLE
fix: add noise extension to return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import type { ConnectionEncrypter } from '@libp2p/interface-connection-encrypter'
 import { Noise } from './noise.js'
 import type { NoiseInit } from './noise.js'
+import type { NoiseExtensions } from './proto/payload.js'
 export * from './crypto.js'
 export * from './crypto/stablelib.js'
 
-export function noise (init: NoiseInit = {}): () => ConnectionEncrypter {
+export function noise (init: NoiseInit = {}): () => ConnectionEncrypter<NoiseExtensions> {
   return () => new Noise(init)
 }


### PR DESCRIPTION
So we can use the types in listeners for interested transports like WebTransport.