### PR TITLE
chore: fix dependabot pr titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   commit-message:
-    prefix: "chore: "
-    prefix-development: "dev: "
+    prefix: "fix: "
+    prefix-development: "chore: "


### PR DESCRIPTION
The Semantic PR action requires the PR title prefix to be `chore:`, `fix:`, `feat:` or `docs:` but the dependabot config has it opening PRs with `dev:` as the title so update the config to have it open PRs with titles that pass the Semantic PR action.