### PR TITLE
chore: Add peer id str to mismatch error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export async function verifySignedPayload (
   // Unmarshaling from PublicKey protobuf
   const payloadPeerId = await peerIdFromKeys(payload.identityKey)
   if (!payloadPeerId.equals(remotePeer)) {
-    throw new Error("Peer ID doesn't match libp2p public key.")
+    throw new Error(`Payload identity key ${payloadPeerId.toString()} does not match expected remote peer ${remotePeer.toString()}`)
   }
   const generatedPayload = getHandshakePayload(noiseStaticKey)
 

--- a/test/xx-handshake.spec.ts
+++ b/test/xx-handshake.spec.ts
@@ -88,7 +88,7 @@ describe('XX Handshake', () => {
       assert(false, 'Should throw exception')
     } catch (e) {
       const err = e as Error
-      expect(err.message).equals("Error occurred while verifying signed payload: Peer ID doesn't match libp2p public key.")
+      expect(err.message).equals(`Error occurred while verifying signed payload: Payload identity key ${peerB.toString()} does not match expected remote peer ${fakePeer.toString()}`)
     }
   })
 
@@ -120,7 +120,7 @@ describe('XX Handshake', () => {
       assert(false, 'Should throw exception')
     } catch (e) {
       const err = e as Error
-      expect(err.message).equals("Error occurred while verifying signed payload: Peer ID doesn't match libp2p public key.")
+      expect(err.message).equals(`Error occurred while verifying signed payload: Payload identity key ${peerA.toString()} does not match expected remote peer ${fakePeer.toString()}`)
     }
   })
 })


### PR DESCRIPTION
- Provide more context to debug mismatch instances like https://github.com/ChainSafe/lodestar/issues/4355