### PR TITLE
fix: use trace logging

### DIFF
--- a/src/handshakes/abstract-handshake.ts
+++ b/src/handshakes/abstract-handshake.ts
@@ -111,7 +111,7 @@ export abstract class AbstractHandshake {
       return derivedU8.subarray(0, 32)
     } catch (e) {
       const err = e as Error
-      logger(err.message)
+      logger.error(err)
       return new Uint8Array(32)
     }
   }


### PR DESCRIPTION
Noise logs in-progress business-as-usual style messages which can make the logs quite noisy.

This PR switches to using trace logging for those messages, you can see them if you include `*:trace` or similar in the debug string.