### PR TITLE
fix: add types to exports in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },


### PR DESCRIPTION
Add types to exports in packages.json，to avoid not being able to locate the type definition file when using exports.
