### PR TITLE
fix: add missing file extension in import

### DIFF
--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -1,4 +1,4 @@
-import type { bytes, uint64 } from './@types/basic'
+import type { bytes, uint64 } from './@types/basic.js'
 
 export const MIN_NONCE = 0
 // For performance reasons, the nonce is represented as a JS `number`


### PR DESCRIPTION
The missing file extension breaks the package for consumers using `node16` module resolution with the following error:
```
node_modules/@chainsafe/libp2p-noise/dist/src/nonce.d.ts:1:36 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './@types/basic.js'?
```

These errors are easy to miss when using `node` module resolution in the library. I can set up another PR to update the module resolution to `node16` so these are easier to catch, if that's ok.