### PR TITLE
fix: concatenate encrypted data length prefix with data before sending

### DIFF
--- a/src/crypto/streaming.ts
+++ b/src/crypto/streaming.ts
@@ -1,3 +1,4 @@
+import { concat as uint8ArrayConcat } from 'uint8arrays'
 import { NOISE_MSG_MAX_LENGTH_BYTES, NOISE_MSG_MAX_LENGTH_BYTES_WITHOUT_TAG } from '../constants.js'
 import { uint16BEEncode } from '../encoder.js'
 import type { IHandshake } from '../@types/handshake-interface.js'
@@ -20,8 +21,10 @@ export function encryptStream (handshake: IHandshake, metrics?: MetricsRegistry)
         const data = handshake.encrypt(chunk.subarray(i, end), handshake.session)
         metrics?.encryptedPackets.increment()
 
-        yield uint16BEEncode(data.byteLength)
-        yield data
+        yield uint8ArrayConcat([
+          uint16BEEncode(data.byteLength),
+          data
+        ], 2 + data.byteLength)
       }
     }
   }


### PR DESCRIPTION
Sending lots of tiny buffers kills TCP performance, even with `noDelay` disabled.

Sending the encrypted data length along with the data in one buffer increases `@libp2p/perf` throughput with noise+yamux from 300-320 MB/s to 320-340 MB/s

Flame graphs showing `Socket._writeGeneric` (e.g. writing to the TCP socket) while running the performance test:

Before:

<img width="389" alt="image" src="https://github.com/ChainSafe/js-libp2p-noise/assets/665810/101be929-1f41-4c2b-a36e-e635e3de2a96">

After:

<img width="274" alt="image" src="https://github.com/ChainSafe/js-libp2p-noise/assets/665810/ff886276-7996-417a-bd23-62fe7cc055d0">
