### PR TITLE
fix: missing import extension

### DIFF
--- a/src/crypto/index.browser.ts
+++ b/src/crypto/index.browser.ts
@@ -1,3 +1,3 @@
-import { pureJsCrypto } from './js'
+import { pureJsCrypto } from './js.js'
 
 export const defaultCrypto = pureJsCrypto


### PR DESCRIPTION
This package is a dependency for https://github.com/waku-org/js-waku

But, due to the import on 'src/crypto/index.browser.ts' - `import { pureJsCrypto } from './.js'`, the CRA does not work. Fixed this by modifying the import

**Steps to reproduce**

1. Create a react app with `npx create-react-app <project-name>`
2. Install the waku sdk package from `npm install @waku/sdk`
3. Package installation fails and throws up the error because of the invalid import

This is a major issue because CRA will not along with package