### PR TITLE
feat: react-native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,5 +111,9 @@
   "browser": {
     "./dist/src/crypto/index.js": "./dist/src/crypto/index.browser.js",
     "util": false
+  },
+  "react-native": {
+    "./dist/src/crypto/index.js": "./dist/src/crypto/index.browser.js",
+    "util": false
   }
 }


### PR DESCRIPTION
React-native doesn't have any node core modules so it must use the pure-js/browser implementations of everything.