### PR TITLE
fix: revert react-native changes in #403

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,11 +109,6 @@
     "sinon": "^17.0.1"
   },
   "browser": {
-    "./dist/src/crypto/index.js": "./dist/src/crypto/index.browser.js",
-    "util": false
-  },
-  "react-native": {
-    "./dist/src/crypto/index.js": "./dist/src/crypto/index.browser.js",
-    "util": false
+    "./dist/src/crypto/index.js": "./dist/src/crypto/index.browser.js"
   }
 }


### PR DESCRIPTION
It turns out this isn't necessary so revert the changes.

Also, we don't depend on node's `util` so no need to override that in the browser field.