### PR TITLE
feat: add service capabilities definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^0.4.1",
     "@libp2p/crypto": "^4.0.0",
-    "@libp2p/interface": "^1.0.0",
+    "@libp2p/interface": "^1.5.0",
     "@libp2p/peer-id": "^4.0.0",
     "@noble/ciphers": "^0.5.1",
     "@noble/curves": "^1.1.0",

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -1,5 +1,5 @@
 import { unmarshalPrivateKey } from '@libp2p/crypto/keys'
-import { type MultiaddrConnection, type SecuredConnection, type PeerId, CodeError, type PrivateKey } from '@libp2p/interface'
+import { type MultiaddrConnection, type SecuredConnection, type PeerId, CodeError, type PrivateKey, serviceCapabilities } from '@libp2p/interface'
 import { peerIdFromKeys } from '@libp2p/peer-id'
 import { decode } from 'it-length-prefixed'
 import { lpStream, type LengthPrefixedStream } from 'it-length-prefixed-stream'
@@ -57,6 +57,13 @@ export class Noise implements INoiseConnection {
     }
     this.prologue = prologueBytes ?? uint8ArrayAlloc(0)
   }
+
+  readonly [Symbol.toStringTag] = '@chainsafe/libp2p-noise'
+
+  readonly [serviceCapabilities]: string[] = [
+    '@libp2p/connection-encryption',
+    '@chainsafe/libp2p-noise'
+  ]
 
   /**
    * Encrypt outgoing data to the remote party (handshake as initiator)


### PR DESCRIPTION
The latest libp2p release allows services to declare their capabilities (what they provide to the node) and their dependencies (the capabilities they require other services to provide for the config to be "valid").

Adds the `serviceCapabilities` symbol property that says Noise provides the `@libp2p/connection-encryption` capability and also that it provides noise encryption as some transports (WebTransport, WebRTC) now require this module to be configured alongside them.