### PR TITLE
fix: support handshake-only with no muxers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "multiformats": "^13.2.2",
         "p-defer": "^4.0.0",
         "protons": "^7.6.0",
-        "sinon": "^19.0.2",
+        "sinon": "^20.0.0",
         "sinon-ts": "^2.0.0"
       }
     },
@@ -109,22 +109,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -157,14 +157,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.5",
+        "@babel/compat-data": "^7.26.8",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
-      "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -225,7 +225,7 @@
         "@babel/helper-optimise-call-expression": "^7.25.9",
         "@babel/helper-replace-supers": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/traverse": "^7.26.9",
+        "@babel/traverse": "^7.27.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
-      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-fO8l08T76v48BhpNRW/nQ0MxfnSdoSKUJBMjubOAYffsVuGG5qOfMq7N6Es7UJvi7Y8goXXo07EfcHZXDPuELQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
-      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -468,27 +468,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -786,13 +786,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
-      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
+      "integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1057,13 +1057,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
-      "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.0.tgz",
+      "integrity": "sha512-LX/vCajUJQDqE7Aum/ELUMZAY19+cDpghxrnyt5I1tV6X5PyC86AOoWXWFYFeIvauyeSA6/ktn4tQVn/3ZifsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "regenerator-transform": "^0.15.2"
       },
       "engines": {
@@ -1074,16 +1074,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.9.tgz",
-      "integrity": "sha512-Jf+8y9wXQbbxvVYTM8gO5oEF2POdNji0NMltEkG7FtmzD9PVz7/lxpqSdTvwsjTMU5HIHuDVNf2SOxLkWi+wPQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.10.tgz",
+      "integrity": "sha512-NWaL2qG6HRpONTnj4JvDU6th4jYeZOJgu3QhmFTCihib0ermtOJqktA5BduGm3suhhVe9EMP9c9+mfJ/I9slqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.26.5",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.6",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
         "semver": "^6.3.1"
       },
@@ -1170,14 +1170,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz",
-      "integrity": "sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
+      "integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.27.0",
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9"
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1220,32 +1220,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1284,9 +1284,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/as-sha256": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.0.0.tgz",
-      "integrity": "sha512-EYw5IZ99Mhn7K8d1eDDH66AFhPy9GcD7bfiqm9mwFjsg8MViEEicGl62b5YPzufBTFh7X7qWAe6yWpr/gbaVEw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.0.1.tgz",
+      "integrity": "sha512-4Y/kQm0LsJ6QRtGcMq6gOdQP+fZhWDfIV2eIqP6oFJZBWYGmdh3wm8YbrXDPLJO87X2Fu6koRLdUS00O3k14Hw==",
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/is-ip": {
@@ -1296,9 +1296,9 @@
       "license": "MIT"
     },
     "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-14.1.0.tgz",
-      "integrity": "sha512-nzFBbHOoRFa/bXUSzmJaXOgHI+EttTldhLJ33yWcM0DxnWhLKychHkCDLoJO3THa1+dnzrDJoxj3N3/V0WoPVw==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-14.1.1.tgz",
+      "integrity": "sha512-EUs2C+xHXXbw0pQQF2AN/ih4qB6BBWOGkDhvHz1VN52o2m/827IBEMT8RHdXMNZciQc90to1L57BKmhXkvztDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.17.5.tgz",
-      "integrity": "sha512-b/Ntabar+g4gsRNwOct909cvatO/auHhNvBzJZfyFQzryI1nqHMaSFuDsrrtzbhQkGJ4GiMAKCXZC2EOdHMgmw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.18.1.tgz",
+      "integrity": "sha512-gxciVVfQqCVXYH0p2Q5D7x7/SgaW3Wv5UjRwO+TCme0P2lVLl/IcfjkujZX+6UQkT7X4QRglXo1QN141UcCRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1386,7 +1386,7 @@
         "@cspell/dict-aws": "^4.0.9",
         "@cspell/dict-bash": "^4.2.0",
         "@cspell/dict-companies": "^3.1.14",
-        "@cspell/dict-cpp": "^6.0.4",
+        "@cspell/dict-cpp": "^6.0.6",
         "@cspell/dict-cryptocurrencies": "^5.0.4",
         "@cspell/dict-csharp": "^4.0.6",
         "@cspell/dict-css": "^4.0.17",
@@ -1396,17 +1396,17 @@
         "@cspell/dict-docker": "^1.1.12",
         "@cspell/dict-dotnet": "^5.0.9",
         "@cspell/dict-elixir": "^4.0.7",
-        "@cspell/dict-en_us": "^4.3.33",
-        "@cspell/dict-en-common-misspellings": "^2.0.9",
+        "@cspell/dict-en_us": "^4.3.35",
+        "@cspell/dict-en-common-misspellings": "^2.0.10",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.11",
         "@cspell/dict-flutter": "^1.1.0",
         "@cspell/dict-fonts": "^4.0.4",
         "@cspell/dict-fsharp": "^1.1.0",
-        "@cspell/dict-fullstack": "^3.2.5",
+        "@cspell/dict-fullstack": "^3.2.6",
         "@cspell/dict-gaming-terms": "^1.1.0",
         "@cspell/dict-git": "^3.0.4",
-        "@cspell/dict-golang": "^6.0.18",
+        "@cspell/dict-golang": "^6.0.19",
         "@cspell/dict-google": "^1.0.8",
         "@cspell/dict-haskell": "^4.0.5",
         "@cspell/dict-html": "^4.0.11",
@@ -1422,21 +1422,21 @@
         "@cspell/dict-markdown": "^2.0.9",
         "@cspell/dict-monkeyc": "^1.0.10",
         "@cspell/dict-node": "^5.0.6",
-        "@cspell/dict-npm": "^5.1.27",
+        "@cspell/dict-npm": "^5.1.31",
         "@cspell/dict-php": "^4.0.14",
         "@cspell/dict-powershell": "^5.0.14",
         "@cspell/dict-public-licenses": "^2.0.13",
-        "@cspell/dict-python": "^4.2.15",
+        "@cspell/dict-python": "^4.2.16",
         "@cspell/dict-r": "^2.1.0",
-        "@cspell/dict-ruby": "^5.0.7",
+        "@cspell/dict-ruby": "^5.0.8",
         "@cspell/dict-rust": "^4.0.11",
         "@cspell/dict-scala": "^5.0.7",
         "@cspell/dict-shell": "^1.1.0",
-        "@cspell/dict-software-terms": "^4.2.5",
+        "@cspell/dict-software-terms": "^5.0.2",
         "@cspell/dict-sql": "^2.2.0",
         "@cspell/dict-svelte": "^1.0.6",
         "@cspell/dict-swift": "^2.0.5",
-        "@cspell/dict-terraform": "^1.1.0",
+        "@cspell/dict-terraform": "^1.1.1",
         "@cspell/dict-typescript": "^3.2.0",
         "@cspell/dict-vue": "^3.0.4"
       },
@@ -1445,22 +1445,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.17.5.tgz",
-      "integrity": "sha512-+eVFCdnda74Frv8hguHYwDtxvqDuJJ/luFRl4dC5oknPMRab0JCHM1DDYjp3NzsehTex0HmcxplxqVW6QoDosg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.18.1.tgz",
+      "integrity": "sha512-/U3/8bcOL5O35fI9F7nN7Mhic0K01ZRxRV/+5jj7atltBbqgFSxViHCZBX0lDZJM96gUHn+3r6q6/8VEJahpDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.17.5"
+        "@cspell/cspell-types": "8.18.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.17.5.tgz",
-      "integrity": "sha512-VOIfFdIo3FYQFcSpIyGkqHupOx0LgfBrWs79IKnTT1II27VUHPF+0oGq0WWf4c2Zpd8tzdHvS3IUhGarWZq69g==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.18.1.tgz",
+      "integrity": "sha512-QHndTQPkR1c02pvvQ7UKFtLjCXgY0OcX8zjTLrCkynmcQxJFjAZAh9cJ7NMOAxab+ciSnkaVf4KWaRSEG17z8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1468,9 +1468,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.17.5.tgz",
-      "integrity": "sha512-5MhYInligPbGctWxoklAKxtg+sxvtJCuRKGSQHHA0JlCOLSsducypl780P6zvpjLK59XmdfC+wtFONxSmRbsuA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.18.1.tgz",
+      "integrity": "sha512-T2sUBv0p9Hnfyg1xT1u3ESKuIWaaIDo0I8idh5DSlTpHgLjdIeAwasmFjEJ28qZv8OKSGawcSQKgJbStfbZASQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.17.5.tgz",
-      "integrity": "sha512-Ur3IK0R92G/2J6roopG9cU/EhoYAMOx2um7KYlq93cdrly8RBAK2NCcGCL7DbjQB6C9RYEAV60ueMUnQ45RrCQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.18.1.tgz",
+      "integrity": "sha512-PwWl7EyhGIu4wHEhvBJb6xVlqMtFwQk0qLDArBvugL6nA+MX9NfG/w7PTgS7tCkFjVF1ku2sDzDLTDWwEk+MLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.17.5.tgz",
-      "integrity": "sha512-91y2+0teunRSRZj940ORDA3kdjyenrUiM+4j6nQQH24sAIAJdRmQl2LG3eUTmeaSReJGkZIpnToQ6DyU5cC88Q==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.18.1.tgz",
+      "integrity": "sha512-d/nMG+qnMbI/1JPm+lD0KcKpgtEHMRsHxkdtGyNCDgvHL/JOGaSHc5ERS3IUgBW0Dfya/3z9wPdaMcHEzt7YCQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1515,9 +1515,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.9.tgz",
-      "integrity": "sha512-bDYdnnJGwSkIZ4gzrauu7qzOs/ZAY/FnU4k11LgdMI8BhwMfsbsy2EI1iS+sD/BI5ZnNT9kU5YR3WADeNOmhRg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.10.tgz",
+      "integrity": "sha512-0qW4sI0GX8haELdhfakQNuw7a2pnWXz3VYQA2MpydH2xT2e6EN9DWFpKAi8DfcChm8MgDAogKkoHtIo075iYng==",
       "dev": true,
       "license": "MIT"
     },
@@ -1532,16 +1532,16 @@
       }
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.14.tgz",
-      "integrity": "sha512-iqo1Ce4L7h0l0GFSicm2wCLtfuymwkvgFGhmu9UHyuIcTbdFkDErH+m6lH3Ed+QuskJlpQ9dM7puMIGqUlVERw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.15.tgz",
+      "integrity": "sha512-vnGYTJFrqM9HdtgpZFOThFTjlPyJWqPi0eidMKyZxMKTHhP7yg6mD5X9WPEPvfiysmJYMnA6KKYQEBqoKFPU9g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.5.tgz",
-      "integrity": "sha512-OrWqPuLf5EV+H/2sIYUSDF4UyiyCR4/+Q2n+xRx09CBg7YBx16h61V9892TKWCUr9FiJfAkKY24aWW3WRU9Nqg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.8.tgz",
+      "integrity": "sha512-BzurRZilWqaJt32Gif6/yCCPi+FtrchjmnehVEIFzbWyeBd/VOUw77IwrEzehZsu5cRU91yPWuWp5fUsKfDAXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1574,9 +1574,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-data-science": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.7.tgz",
-      "integrity": "sha512-XhAkK+nSW6zmrnWzusmZ1BpYLc62AWYHZc2p17u4nE2Z9XG5DleG55PCZxXQTKz90pmwlhFM9AfpkJsYaBWATA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.8.tgz",
+      "integrity": "sha512-uyAtT+32PfM29wRBeAkUSbkytqI8bNszNfAz2sGPtZBRmsZTYugKMEO9eDjAIE/pnT9CmbjNuoiXhk+Ss4fCOg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1588,9 +1588,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-docker": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.12.tgz",
-      "integrity": "sha512-6d25ZPBnYZaT9D9An/x6g/4mk542R8bR3ipnby3QFCxnfdd6xaWiTcwDPsCgwN2aQZIQ1jX/fil9KmBEqIK/qA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.13.tgz",
+      "integrity": "sha512-85X+ZC/CPT3ie26DcfeMFkZSNuhS8DlAqPXzAjilHtGE/Nj+QnS3jyBz0spDJOJrjh8wx1+ro2oCK98sbVcztw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1609,16 +1609,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.34",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.34.tgz",
-      "integrity": "sha512-ewJXNV7Nk5vxbGvHvxYLDGoXN0Lq5sfSgX8SAlcYL+2bZ7r25nNOLHou5hdFlNgvviGTx/SFPlVKjdjVJlblgA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.1.tgz",
+      "integrity": "sha512-OqIImYIrTAg+lpS+1v/KtjI2kyiw1bD3FqGbuXUxpAc+e+pWluW7rPjsJCxTRlruKQMSCgQeK6N054XnxHdkDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.9.tgz",
-      "integrity": "sha512-O/jAr1VNtuyCFckbTmpeEf43ZFWVD9cJFvWaA6rO2IVmLirJViHWJUyBZOuQcesSplzEIw80MAYmnK06/MDWXQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.10.tgz",
+      "integrity": "sha512-80mXJLtr0tVEtzowrI7ycVae/ULAYImZUlr0kUTpa8i57AUk7Zy3pYBs44EYIKW7ZC9AHu4Qjjfq4vriAtyTDQ==",
       "dev": true,
       "license": "CC BY-SA 4.0"
     },
@@ -1665,9 +1665,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-gaming-terms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.0.tgz",
-      "integrity": "sha512-46AnDs9XkgJ2f1Sqol1WgfJ8gOqp60fojpc9Wxch7x+BA63g4JfMV5/M5x0sI0TLlLY8EBSglcr8wQF/7C80AQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.1.tgz",
+      "integrity": "sha512-tb8GFxjTLDQstkJcJ90lDqF4rKKlMUKs5/ewePN9P+PYRSehqDpLI5S5meOfPit8LGszeOrjUdBQ4zXo7NpMyQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1679,9 +1679,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.18.tgz",
-      "integrity": "sha512-Mt+7NwfodDwUk7423DdaQa0YaA+4UoV3XSxQwZioqjpFBCuxfvvv4l80MxCTAAbK6duGj0uHbGTwpv8fyKYPKg==",
+      "version": "6.0.20",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.20.tgz",
+      "integrity": "sha512-b7nd9XXs+apMMzNSWorjirQsbmlwcTC0ViQJU8u+XNose3z0y7oNeEpbTPTVoN1+1sO9aOHuFwfwoOMFCDS14Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1770,16 +1770,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-markdown": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.9.tgz",
-      "integrity": "sha512-j2e6Eg18BlTb1mMP1DkyRFMM/FLS7qiZjltpURzDckB57zDZbUyskOFdl4VX7jItZZEeY0fe22bSPOycgS1Z5A==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.10.tgz",
+      "integrity": "sha512-vtVa6L/84F9sTjclTYDkWJF/Vx2c5xzxBKkQp+CEFlxOF2SYgm+RSoEvAvg5vj4N5kuqR4350ZlY3zl2eA3MXw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@cspell/dict-css": "^4.0.17",
         "@cspell/dict-html": "^4.0.11",
         "@cspell/dict-html-symbol-entities": "^4.0.3",
-        "@cspell/dict-typescript": "^3.2.0"
+        "@cspell/dict-typescript": "^3.2.1"
       }
     },
     "node_modules/@cspell/dict-monkeyc": {
@@ -1790,16 +1790,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.6.tgz",
-      "integrity": "sha512-CEbhPCpxGvRNByGolSBTrXXW2rJA4bGqZuTx1KKO85mwR6aadeOmUE7xf/8jiCkXSy+qvr9aJeh+jlfXcsrziQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.7.tgz",
+      "integrity": "sha512-ZaPpBsHGQCqUyFPKLyCNUH2qzolDRm1/901IO8e7btk7bEDF56DN82VD43gPvD4HWz3yLs/WkcLa01KYAJpnOw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.29",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.29.tgz",
-      "integrity": "sha512-FPCE9MpO42WGc9u/lx3J6CZSfPVO5kMUaOQkTVqXo3sTDX6+o5ulb+9W/MD33kiA0AvXr1Lk8knhA6koW9t/Yw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.0.tgz",
+      "integrity": "sha512-kTUdbSE8SuIMKMlASMbI8/SEwv3EmI8eBcwdrtu4PHA+XVx+8JvQCB5fcWK9mn/94Y7LQ1kDIm+yfAZfwopY0A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1825,13 +1825,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.15.tgz",
-      "integrity": "sha512-VNXhj0Eh+hdHN89MgyaoSAexBQKmYtJaMhucbMI7XmBs4pf8fuFFN3xugk51/A4TZJr8+RImdFFsGMOw+I4bDA==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.17.tgz",
+      "integrity": "sha512-xqMKfVc8d7yDaOChFdL2uWAN3Mw9qObB/Zr6t5w1OHbi23gWs7V1lI9d0mXAoqSK6N3mosbum4OIq/FleQDnlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/dict-data-science": "^2.0.7"
+        "@cspell/dict-data-science": "^2.0.8"
       }
     },
     "node_modules/@cspell/dict-r": {
@@ -1842,9 +1842,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.7.tgz",
-      "integrity": "sha512-4/d0hcoPzi5Alk0FmcyqlzFW9lQnZh9j07MJzPcyVO62nYJJAGKaPZL2o4qHeCS/od/ctJC5AHRdoUm0ktsw6Q==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.8.tgz",
+      "integrity": "sha512-ixuTneU0aH1cPQRbWJvtvOntMFfeQR2KxT8LuAv5jBKqQWIHSxzGlp+zX3SVyoeR0kOWiu64/O5Yn836A5yMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1870,9 +1870,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.2.5.tgz",
-      "integrity": "sha512-CaRzkWti3AgcXoxuRcMijaNG7YUk/MH1rHjB8VX34v3UdCxXXeqvRyElRKnxhFeVLB/robb2UdShqh/CpskxRg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.0.5.tgz",
+      "integrity": "sha512-ZjAOa8FI8/JrxaRqKT3eS7AQXFjU174xxQoKYMkmdwSyNIj7WUCAg10UeLqeMjFVv36zIO0Hm0dD2+Bvn18SLA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1905,9 +1905,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-typescript": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.0.tgz",
-      "integrity": "sha512-Pk3zNePLT8qg51l0M4g1ISowYAEGxTuNfZlgkU5SvHa9Cu7x/BWoyYq9Fvc3kAyoisCjRPyvWF4uRYrPitPDFw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.1.tgz",
+      "integrity": "sha512-jdnKg4rBl75GUBTsUD6nTJl7FGvaIt5wWcWP7TZSC3rV1LfkwvbUiY3PiGpfJlAIdnLYSeFWIpYU9gyVgz206w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1919,13 +1919,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.17.5.tgz",
-      "integrity": "sha512-tY+cVkRou+0VKvH+K1NXv8/R7mOlW3BDGSs9fcgvhatj0m00Yf8blFC7tE4VVI9Qh2bkC/KDFqM24IqZbuwXUQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.18.1.tgz",
+      "integrity": "sha512-VJHfS/Iv0Rx7wn1pjPmwgsaw6r72N5Cx2gL0slWk8Cogc8YiK7/6jsGnsvxJZVkHntJoiT8PrkIvhNKb3awD3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.5",
+        "@cspell/url": "8.18.1",
         "import-meta-resolve": "^4.1.0"
       },
       "engines": {
@@ -1933,9 +1933,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.17.5.tgz",
-      "integrity": "sha512-Fj6py2Rl+FEnMiXhRQUM1A5QmyeCLxi6dY/vQ0qfH6tp6KSaBiaC8wuPUKhr8hKyTd3+8lkUbobDhUf6xtMEXg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.18.1.tgz",
+      "integrity": "sha512-vTOb2itP0pjrccvt8wcKiTGyw0pFMTPI85H12T6n8ZhqXTktPgQH2gEf/SU/5tkPNnBKr4GJ+FdU5hJ27HzgXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.17.5.tgz",
-      "integrity": "sha512-Z4eo+rZJr1086wZWycBiIG/n7gGvVoqn28I7ZicS8xedRYu/4yp2loHgLn4NpxG3e46+dNWs4La6vinod+UydQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.18.1.tgz",
+      "integrity": "sha512-gsgv+5ZQD4aHNHDdfNGoafVYkqRynyYgaodt9Dp/3o0YKYcxGf2jrX8SJ35MfZ61qln0n7P4Djrg+bFV2zNH5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1953,9 +1953,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.5.tgz",
-      "integrity": "sha512-GNQqST7zI85dAFVyao6oiTeg5rNhO9FH1ZAd397qQhvwfxrrniNfuoewu8gPXyP0R4XBiiaCwhBL7w9S/F5guw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.18.1.tgz",
+      "integrity": "sha512-FRJbLYDC9ucpTOzbF6MohP2u5X3NU5L0RoVuoYCynqm/QOI38XP6WOEaI4H58CAn857bOIKZk0LZRPTGzi6Qlg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
-      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
       "cpu": [
         "ppc64"
       ],
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
-      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
       "cpu": [
         "arm"
       ],
@@ -2113,9 +2113,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
-      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
       "cpu": [
         "arm64"
       ],
@@ -2130,9 +2130,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
-      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
       "cpu": [
         "x64"
       ],
@@ -2147,9 +2147,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
-      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
       "cpu": [
         "arm64"
       ],
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
-      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
       "cpu": [
         "x64"
       ],
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
       "cpu": [
         "arm64"
       ],
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
-      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
       "cpu": [
         "x64"
       ],
@@ -2215,9 +2215,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
-      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
       "cpu": [
         "arm"
       ],
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
-      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
       "cpu": [
         "arm64"
       ],
@@ -2249,9 +2249,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
-      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
       "cpu": [
         "ia32"
       ],
@@ -2266,9 +2266,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
-      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
       "cpu": [
         "loong64"
       ],
@@ -2283,9 +2283,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
-      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
       "cpu": [
         "mips64el"
       ],
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
-      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
       "cpu": [
         "ppc64"
       ],
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
-      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
       "cpu": [
         "riscv64"
       ],
@@ -2334,9 +2334,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
-      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
       "cpu": [
         "s390x"
       ],
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
-      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
       "cpu": [
         "x64"
       ],
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
       "cpu": [
         "arm64"
       ],
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
       "cpu": [
         "x64"
       ],
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
       "cpu": [
         "arm64"
       ],
@@ -2419,9 +2419,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
       "cpu": [
         "x64"
       ],
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
-      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
       "cpu": [
         "x64"
       ],
@@ -2453,9 +2453,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
-      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
       "cpu": [
         "arm64"
       ],
@@ -2470,9 +2470,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
-      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
       "cpu": [
         "ia32"
       ],
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
-      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
       "cpu": [
         "x64"
       ],
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz",
+      "integrity": "sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2984,12 +2984,12 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.15.tgz",
-      "integrity": "sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz",
+      "integrity": "sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface": "^2.9.0",
         "@noble/curves": "^1.7.0",
         "@noble/hashes": "^1.6.1",
         "multiformats": "^13.3.1",
@@ -3128,46 +3128,23 @@
       }
     },
     "node_modules/@libp2p/echo": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/echo/-/echo-2.1.16.tgz",
-      "integrity": "sha512-JJpGGN+q94JxNiWLGIIx14LKgcb5B5Hb4gy96xZ3uv8A5rhZ4bsspG4ln+72Rv8EbwF+A6/XSdyMTpuwrw7VPw==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@libp2p/echo/-/echo-2.1.20.tgz",
+      "integrity": "sha512-xxOkBWjBABzWDvvLM6/58X0fwvDl4mTW1N2G4T7eCVK4nnH3oifEhbCw8JMXV6tmt3uAB5OTbfK2tHbMeqqROg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/interface-internal": "^2.3.7",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
         "@multiformats/multiaddr": "^12.3.3",
-        "it-byte-stream": "^1.1.0",
+        "it-byte-stream": "^2.0.1",
         "it-pipe": "^3.0.1"
       }
     },
-    "node_modules/@libp2p/echo/node_modules/it-byte-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
-      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-queueless-pushable": "^1.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@libp2p/echo/node_modules/it-queueless-pushable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
-      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.1",
-        "race-signal": "^1.1.3"
-      }
-    },
     "node_modules/@libp2p/interface": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.7.0.tgz",
-      "integrity": "sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz",
+      "integrity": "sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/multiaddr": "^12.3.3",
@@ -3179,23 +3156,23 @@
       }
     },
     "node_modules/@libp2p/interface-compliance-tests": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-compliance-tests/-/interface-compliance-tests-6.4.0.tgz",
-      "integrity": "sha512-2dHfKJlVVHTits3SUSmAD5UdjFJyHZRiwBNiTS2R9xSzApS/AoFmH29sYGAUzXDoOPZyCe4UW4kv00cnurSAig==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-compliance-tests/-/interface-compliance-tests-6.4.4.tgz",
+      "integrity": "sha512-cNpxGsEG2VChFCDEgk2qwm7a/osafZWVTd5e5owhy/e/S93rSWqeWq40xSJ4zya5L6zZymPkX0GxvQffLB5oZg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/echo": "^2.1.16",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/interface-internal": "^2.3.7",
-        "@libp2p/logger": "^5.1.12",
-        "@libp2p/memory": "^1.1.3",
-        "@libp2p/multistream-select": "^6.0.19",
-        "@libp2p/peer-collections": "^6.0.23",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/plaintext": "^2.0.19",
-        "@libp2p/utils": "^6.5.7",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/echo": "^2.1.20",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/logger": "^5.1.15",
+        "@libp2p/memory": "^1.1.6",
+        "@libp2p/multistream-select": "^6.0.22",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/plaintext": "^2.0.22",
+        "@libp2p/utils": "^6.6.2",
         "@multiformats/multiaddr": "^12.3.3",
         "@multiformats/multiaddr-matcher": "^1.6.0",
         "abortable-iterator": "^5.1.0",
@@ -3203,17 +3180,17 @@
         "any-signal": "^4.1.1",
         "delay": "^6.0.0",
         "it-all": "^3.0.6",
-        "it-byte-stream": "^1.1.0",
+        "it-byte-stream": "^2.0.1",
         "it-drain": "^3.0.7",
         "it-map": "^3.1.1",
         "it-ndjson": "^1.0.7",
         "it-pair": "^2.0.6",
         "it-pipe": "^3.0.1",
-        "it-protobuf-stream": "^1.1.5",
+        "it-protobuf-stream": "^2.0.1",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
         "it-to-buffer": "^4.0.7",
-        "libp2p": "^2.8.0",
+        "libp2p": "^2.8.4",
         "merge-options": "^3.0.4",
         "p-defer": "^4.0.1",
         "p-event": "^6.0.1",
@@ -3227,38 +3204,47 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/interface-compliance-tests/node_modules/it-byte-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
-      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
+    "node_modules/@libp2p/interface-compliance-tests/node_modules/it-protobuf-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.1.tgz",
+      "integrity": "sha512-szhw8w2aIENUa1yv0vFgGZDs7e81dQ/7dM10c4Rf6+rs5tqzWVCSLbpgxIYM0cA8KlcI66XGdzu6lyYp6jKdvw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-queueless-pushable": "^1.0.0",
+        "abort-error": "^1.0.1",
+        "it-length-prefixed-stream": "^2.0.0",
         "it-stream-types": "^2.0.2",
         "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/@libp2p/interface-compliance-tests/node_modules/it-queueless-pushable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
-      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
+    "node_modules/@libp2p/interface-compliance-tests/node_modules/sinon": {
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.5.tgz",
+      "integrity": "sha512-r15s9/s+ub/d4bxNXqIUmwp6imVSdTorIRaxoecYjqTVLZ8RuoXr/4EDGwIBo6Waxn7f2gnURX9zuhAfCwaF6Q==",
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "p-defer": "^4.0.1",
-        "race-signal": "^1.1.3"
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.7.tgz",
-      "integrity": "sha512-u0I4zqUJhhPbL2ReX88068Sudv2uA/Z1sn6EeD8mr5kkGActTrzxoTjjxscmiQgQybOVyvJbkTiJciorT0ZyPw==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.11.tgz",
+      "integrity": "sha512-/7GMkn8F9ojFgUmgkiyP0LeVQ4AKinyn2PdFCPOzQszcN3rVHOi6mtZYXNsGjftoP3QZQ4udadbytzGE3pmVYA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/peer-collections": "^6.0.23",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-collections": "^6.0.27",
         "@multiformats/multiaddr": "^12.3.3",
         "progress-events": "^1.0.1"
       }
@@ -3329,19 +3315,19 @@
       }
     },
     "node_modules/@libp2p/kad-dht": {
-      "version": "14.2.13",
-      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-14.2.13.tgz",
-      "integrity": "sha512-ElEB936lLrahuNP51X7+W1xIPLXw7rNLcrqk3L69fT3wx+VigqBRD3ApPvylVo3jgeeFYmMBrMmoptnwq2GdYQ==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-14.2.15.tgz",
+      "integrity": "sha512-iARZsaKrm9LlOE0nRTsqMasYGfWbh+zw1TAMWOY/QHTszFGb9ol7FZoI9WUzoif9ltKLu3BjJpy00b8CVofCBw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.0.15",
         "@libp2p/interface": "^2.7.0",
-        "@libp2p/interface-internal": "^2.3.7",
-        "@libp2p/peer-collections": "^6.0.23",
-        "@libp2p/peer-id": "^5.0.16",
+        "@libp2p/interface-internal": "^2.3.9",
+        "@libp2p/peer-collections": "^6.0.25",
+        "@libp2p/peer-id": "^5.1.0",
         "@libp2p/record": "^4.0.5",
-        "@libp2p/utils": "^6.5.7",
+        "@libp2p/utils": "^6.6.0",
         "@multiformats/multiaddr": "^12.3.3",
         "any-signal": "^4.1.1",
         "interface-datastore": "^8.3.1",
@@ -3368,13 +3354,13 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.12.tgz",
-      "integrity": "sha512-9K18gnPXxPkgPTQKHgCYaUimlbYheAEogDXvYme1TsPEBPH9oYTVsFpZhe5r92auE3aNuzUSR3VD0TCs/bAZ7g==",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.15.tgz",
+      "integrity": "sha512-0+rOHEXXDNZvsb9p04jVAFQB0WcvMxFfqzSe271/tg4yVlPF5H99l5BwOqeb+EYhHV1lTk+zrJdPK9easHr1fQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface": "^2.9.0",
         "@multiformats/multiaddr": "^12.3.3",
         "interface-datastore": "^8.3.1",
         "multiformats": "^13.3.1",
@@ -3382,13 +3368,13 @@
       }
     },
     "node_modules/@libp2p/memory": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/memory/-/memory-1.1.3.tgz",
-      "integrity": "sha512-DOHRG6qTU0YWrzFXHEzUkfQXUISSWk0SzYrhi2cCTW931Vrk30P+kXelKTxt15sPZax4z92jRL6CGFYyv2mM3Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/memory/-/memory-1.1.6.tgz",
+      "integrity": "sha512-2kJO3m3kuL/N5x/DasTWmXRcLoKdUaRJhD1fL8NbW6ldZ53caha2defXOKRDXn41I9quCmeBbnfh2fiX7cvYtA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface": "^2.9.0",
         "@multiformats/multiaddr": "^12.3.3",
         "@multiformats/multiaddr-matcher": "^1.6.0",
         "@types/sinon": "^17.0.3",
@@ -3401,15 +3387,15 @@
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "6.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.19.tgz",
-      "integrity": "sha512-Ngh9Lc376pBCpCAZb7VnTHgvuVIieEnLkrDkeniJl6wGZEr8ysOj2VkxccXHKe0DnOWQfqRZUonUWVRjFT/SUw==",
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.22.tgz",
+      "integrity": "sha512-SCSnLKNvqulYYN52mG/b5INGlmj3rMAxtH9zVb1e9rq5WflJu7CGaV8CJsxOjRoJ7YqPgx1meywkeG989OdwDA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface": "^2.9.0",
         "it-length-prefixed": "^10.0.1",
-        "it-length-prefixed-stream": "^1.2.0",
+        "it-length-prefixed-stream": "^2.0.1",
         "it-stream-types": "^2.0.2",
         "p-defer": "^4.0.1",
         "race-signal": "^1.1.2",
@@ -3418,78 +3404,42 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/multistream-select/node_modules/it-byte-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
-      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-queueless-pushable": "^1.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/it-length-prefixed-stream": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.1.tgz",
-      "integrity": "sha512-FYqlxc2toUoK+aPO5r3KDBIUG1mOvk2DzmjQcsfLUTHRWMJP4Va9855tVzg/22Bj+VUUaT7gxBg7HmbiCxTK4w==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-byte-stream": "^1.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/it-queueless-pushable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
-      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.1",
-        "race-signal": "^1.1.3"
-      }
-    },
     "node_modules/@libp2p/peer-collections": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.23.tgz",
-      "integrity": "sha512-eJYmiq2KeUpm5727bl2ngSOnxPnc/VzKnHL2s30x9DfGxl2KpsFBuqAhnjpe5eCshHfQhXsIdbH+5IkY9jobrQ==",
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.27.tgz",
+      "integrity": "sha512-JLA7N9OgcxfxnSU3IpZ1DLXHCW64VH/WgJm/lFtPXjIfknO0hU2feerdB2sz/QBAAmehJHqBBSlao57BKo7KLg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/utils": "^6.5.7",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
         "multiformats": "^13.3.1"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.0.16.tgz",
-      "integrity": "sha512-gRVTWk8LvkSBStvqxc4A1JycEo4H+rJwwefdBmLR+d3fHiUf/2Y6t5elQJzouxykwurAglr8DnUhwCB/pQ9eQQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz",
+      "integrity": "sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
         "multiformats": "^13.3.1",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "8.0.23",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.23.tgz",
-      "integrity": "sha512-IY/pO1keAw3XkT6VBba1UDmGd6J7Aw3pVy3l5lQzFyb+thelwNqeDAt+xwwi5il3QGK5FiBcdd78MFg2DPue6Q==",
+      "version": "8.0.27",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.27.tgz",
+      "integrity": "sha512-F2sWv0++WrHRuEYtqqvFOa+748rCekQuEBj9OKvDCxS3gtQeEgVLfsNAvM/vRPN0Lx3m4OF44tui2KpV7NU6jA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/utils": "^6.5.7",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
         "@multiformats/multiaddr": "^12.3.3",
         "multiformats": "^13.3.1",
         "protons-runtime": "^5.5.0",
@@ -3499,16 +3449,16 @@
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.1.0.tgz",
-      "integrity": "sha512-HGr870ZFS8SCvEDrJr0hSw6bqzgQoWwdgIZv9txQKryohPT7dRgB7K2L9GdzYu92FTPuF524bEaYYhHPPfCUVw==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.1.4.tgz",
+      "integrity": "sha512-KUfY0GJLUUYrPGLsiGRWliNNFPGlC0bY4BE25jhp1MEsjrimkTl6TcksqCQ8SzR0Cn4HMRRPJs4H2AzdaQexZA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/peer-record": "^8.0.23",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-record": "^8.0.27",
         "@multiformats/multiaddr": "^12.3.3",
         "interface-datastore": "^8.3.1",
         "it-all": "^3.0.6",
@@ -3520,35 +3470,48 @@
       }
     },
     "node_modules/@libp2p/plaintext": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/plaintext/-/plaintext-2.0.19.tgz",
-      "integrity": "sha512-eMdMUPauibL3CDSGfucVwK28ML2go0m5HCk2naJvrJ2QWn5skoFjIQROl/17CdwhNfUwwFOoOklEHcGxRpStdA==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@libp2p/plaintext/-/plaintext-2.0.22.tgz",
+      "integrity": "sha512-Ja8JkHndFMNsoQ5ws9aiT+kM3gqEOIWAJKc1cqFuG6jyfMyh/BV1y+reQwt0m7PyT0LVev8Mww8pMiHV5mvhDw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/peer-id": "^5.0.16",
-        "it-protobuf-stream": "^1.1.5",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "it-protobuf-stream": "^2.0.1",
         "it-stream-types": "^2.0.2",
         "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/pubsub": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-10.1.6.tgz",
-      "integrity": "sha512-SXBUyThwnB8xme4B6rkhkwPZJbMbWuLWgKJMFzQ/bnQdHTtoFHjRKNaEWq11Gi4AYkpKvwxh/IrTbC2KEo//TA==",
+    "node_modules/@libp2p/plaintext/node_modules/it-protobuf-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.1.tgz",
+      "integrity": "sha512-szhw8w2aIENUa1yv0vFgGZDs7e81dQ/7dM10c4Rf6+rs5tqzWVCSLbpgxIYM0cA8KlcI66XGdzu6lyYp6jKdvw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/interface-internal": "^2.3.7",
-        "@libp2p/peer-collections": "^6.0.23",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/utils": "^6.5.7",
+        "abort-error": "^1.0.1",
+        "it-length-prefixed-stream": "^2.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/pubsub": {
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-10.1.10.tgz",
+      "integrity": "sha512-PJiHERHJ1NFJpTuQjYLhTsMO0tvaP7MXlWlkRpJ6eShYZ4x8CAZI5/5A7pICQdptyHXRU92mkAOTn38YrZ5c/w==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
         "it-length-prefixed": "^10.0.1",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
@@ -3571,16 +3534,16 @@
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-10.1.6.tgz",
-      "integrity": "sha512-4+bXxQ2MgsNVISmGcAsqsdwSWtnOpa0/9RPiCbSQsYvHdQJ5bHTE0GdcYe0XDWpn1C83faAU41o8n8fMTeVbbQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-10.1.10.tgz",
+      "integrity": "sha512-OpzojfJQgg8Cy9g/c/OqI2y5M58stvpbEqh+zWdgLn6J7iJaIigL5M3Hls6Fn7KZtxshfqaKDIrD/x/Le8+A8w==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/utils": "^6.5.7",
-        "@multiformats/mafmt": "^12.1.6",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/utils": "^6.6.2",
         "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
         "@types/sinon": "^17.0.3",
         "p-defer": "^4.0.1",
         "p-event": "^6.0.1",
@@ -3590,17 +3553,17 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.5.7.tgz",
-      "integrity": "sha512-fu6oRgSCOYlbuQObuF/ZVynMc7vdAfekxfi7B7TW6KjZEWmzeErvX1iEk9pfyJo5D0IxBCIMPRkN+Rr5MDfNWg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.2.tgz",
+      "integrity": "sha512-PjbKA0+l+8mmM7quOnG0D7XKdlF/3Hi5Aco3D0ZQXW68QnzmjEEeTbky1gzrZUgnMBmb2ZYrBlZd0GpsJ7Rc9Q==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/logger": "^5.1.12",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/logger": "^5.1.15",
         "@multiformats/multiaddr": "^12.3.3",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
@@ -3634,16 +3597,6 @@
         "uint8arrays": "^5.0.2"
       }
     },
-    "node_modules/@multiformats/mafmt": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
-      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      }
-    },
     "node_modules/@multiformats/multiaddr": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.4.0.tgz",
@@ -3659,9 +3612,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr-matcher": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.6.0.tgz",
-      "integrity": "sha512-E77lLvQR+50kTAfvjV3g4wr9qCu77Z+6yT0s1hgfh8B4sAXZ8u/YdQJGhjgstgW1kmGy7BXPppROKYijqQsesQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.7.0.tgz",
+      "integrity": "sha512-WfobrJy7XLaYL7PQ3IcFoXdGN5jmdv5FsuKQkZIIreC1pSR4Q9PSOWu2ULxP/M2JT738Xny0PFoCke0ENbyfww==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -3698,12 +3651,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
+      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.7.2"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -3713,9 +3666,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -3773,17 +3726,17 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
-      "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
+      "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.1.2",
-        "@octokit/request": "^9.2.1",
-        "@octokit/request-error": "^6.1.7",
-        "@octokit/types": "^13.6.2",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
         "before-after-hook": "^3.0.2",
         "universal-user-agent": "^7.0.0"
       },
@@ -3792,13 +3745,13 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
-      "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.6.2",
+        "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -3806,14 +3759,14 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
-      "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^9.2.2",
-        "@octokit/types": "^13.8.0",
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -3821,20 +3774,20 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.0.0.tgz",
+      "integrity": "sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.4.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.3.tgz",
-      "integrity": "sha512-tBXaAbXkqVJlRoA/zQVe9mUdb8rScmivqtpv3ovsC5xhje/a+NOCivs7eUhWBwCApJVsR4G5HMeaLbq7PxqZGA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.7.0"
+        "@octokit/types": "^13.10.0"
       },
       "engines": {
         "node": ">= 18"
@@ -3843,15 +3796,32 @@
         "@octokit/core": ">=6"
       }
     },
-    "node_modules/@octokit/plugin-retry": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.4.tgz",
-      "integrity": "sha512-7AIP4p9TttKN7ctygG4BtR7rrB0anZqoU9ThXFk8nETqIfvgPUANTSYHqWYknK7W3isw59LpZeLI8pcEwiJdRg==",
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/request-error": "^6.1.7",
-        "@octokit/types": "^13.6.2",
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.2.1.tgz",
+      "integrity": "sha512-wUc3gv0D6vNHpGxSaR3FlqJpTXGWgqmk607N9L3LvPL4QjaxDgX/1nY2mGpT37Khn+nlIXdljczkRnNdTTV3/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -3862,9 +3832,9 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.4.0.tgz",
-      "integrity": "sha512-IOlXxXhZA4Z3m0EEYtrrACkuHiArHLZ3CvqWwOez/pURNqRuwfoFlTPbN5Muf28pzFuztxPyiUiNwz8KctdZaQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.6.1.tgz",
+      "integrity": "sha512-bt3EBUkeKUzDQXRCcFrR9SWVqlLFRRqcCrr6uAorWt6NXTyjMKqcGrFmXqJy9NCbnKgiIZ2OXWq04theFc76Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3878,16 +3848,33 @@
         "@octokit/core": "^6.1.3"
       }
     },
-    "node_modules/@octokit/request": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
-      "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
+    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^10.1.3",
-        "@octokit/request-error": "^6.1.7",
-        "@octokit/types": "^13.6.2",
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
+      "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
         "fast-content-type-parse": "^2.0.0",
         "universal-user-agent": "^7.0.2"
       },
@@ -3896,26 +3883,26 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
-      "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.6.2"
+        "@octokit/types": "^14.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.0.0.tgz",
+      "integrity": "sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^25.0.0"
       }
     },
     "node_modules/@phenomnomnominal/tsquery": {
@@ -3943,9 +3930,9 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4716,13 +4703,13 @@
       }
     },
     "node_modules/@types/chai-subset": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.5.tgz",
-      "integrity": "sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz",
+      "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/chai": "*"
+      "peerDependencies": {
+        "@types/chai": "<5.2.0"
       }
     },
     "node_modules/@types/debug": {
@@ -4846,12 +4833,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -4886,9 +4873,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5455,9 +5442,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5504,9 +5491,9 @@
       }
     },
     "node_modules/aegir": {
-      "version": "45.1.2",
-      "resolved": "https://registry.npmjs.org/aegir/-/aegir-45.1.2.tgz",
-      "integrity": "sha512-dBCjF9ZM/KHPQHPT2lI7VUq54QqH+s74kW16c2s+/iYh/1S/wI5Una5FGvS3zX36H4GPceMzL7NbFIk9rT1RDw==",
+      "version": "45.1.4",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-45.1.4.tgz",
+      "integrity": "sha512-xS+AW251ok7GySAii4flQpQL3qdoGJdr2VJ3j5De84iAuDMPVi/eVxlVP3AmtQ22xcujUhUD3UgbZqgq7QlkCQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -6015,18 +6002,19 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
-      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6194,14 +6182,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
-      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
+      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "@babel/helper-define-polyfill-provider": "^0.6.4",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -6219,27 +6207,27 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.2",
-        "core-js-compat": "^3.38.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
-      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
+      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.3"
+        "@babel/helper-define-polyfill-provider": "^0.6.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6268,25 +6256,33 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.1.tgz",
-      "integrity": "sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "bare-events": "^2.0.0",
+        "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.0.0"
+        "bare-stream": "^2.6.4"
       },
       "engines": {
-        "bare": ">=1.7.0"
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
       }
     },
     "node_modules/bare-os": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.5.1.tgz",
-      "integrity": "sha512-LvfVNDcWLw2AnIw5f2mWUgumW3I3N/WYGiWeimhQC1Ybt71n2FjlS9GJKeCnFeg1MKZHxzIFmpFnBXDI+sBeFg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -6484,9 +6480,9 @@
       }
     },
     "node_modules/browser-readablestream-to-it": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.7.tgz",
-      "integrity": "sha512-g1Aznml3HmqTLSXylZhGwdfnAa67+vlNAYhT9ROJZkAxY7yYmWusND10olvCMPe4sVhZyVwn5tPkRzOg85kBEg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.8.tgz",
+      "integrity": "sha512-+aDq+8QoTxIklc9m21oVg96Bm18EpeVke4/8vWPNu+9Ktd+G4PYavitE4gv/pjIndw1q+vxE/Rcnv1zYHrEQbQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
@@ -6875,9 +6871,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001702",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
-      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
+      "version": "1.0.30001714",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
+      "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
       "dev": true,
       "funding": [
         {
@@ -6972,9 +6968,9 @@
       "license": "MIT"
     },
     "node_modules/chai-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.6.0.tgz",
+      "integrity": "sha512-sXV7whDmpax+8H++YaZelgin7aur1LGf9ZhjZa3ojETFJ0uPVuS4XEXuIagpZ/c8uVOtsSh4MwOjy5CBLjJSXA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7820,25 +7816,25 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.17.5.tgz",
-      "integrity": "sha512-l3Cfp87d7Yrodem675irdxV6+7+OsdR+jNwYHe33Dgnd6ePEfooYrvmfGdXF9rlQrNLUQp/HqYgHJzSq19UEsg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.18.1.tgz",
+      "integrity": "sha512-RE3LIgN9NAVcYBNX2NQVhLergok8EPymOuCUhu1vBR8cjRmioksn3CJeCoQgD8rPjalM+S9thYkMtOZc5Jjv2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.17.5",
-        "@cspell/cspell-pipe": "8.17.5",
-        "@cspell/cspell-types": "8.17.5",
-        "@cspell/dynamic-import": "8.17.5",
-        "@cspell/url": "8.17.5",
+        "@cspell/cspell-json-reporter": "8.18.1",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "@cspell/dynamic-import": "8.18.1",
+        "@cspell/url": "8.18.1",
         "chalk": "^5.4.1",
         "chalk-template": "^1.1.0",
         "commander": "^13.1.0",
-        "cspell-dictionary": "8.17.5",
-        "cspell-gitignore": "8.17.5",
-        "cspell-glob": "8.17.5",
-        "cspell-io": "8.17.5",
-        "cspell-lib": "8.17.5",
+        "cspell-dictionary": "8.18.1",
+        "cspell-gitignore": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-io": "8.18.1",
+        "cspell-lib": "8.18.1",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
@@ -7857,13 +7853,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.17.5.tgz",
-      "integrity": "sha512-XDc+UJO5RZ9S9e2Ajz332XjT7dv6Og2UqCiSnAlvHt7t/MacLHSPARZFIivheObNkWZ7E1iWI681RxKoH4o40w==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.18.1.tgz",
+      "integrity": "sha512-zdJ0uhLROSUrHoibysPw+AkxKPUmiG95hDtiL7s8smewkuaS1hpjqwsDBx981nHYs3xW3qDUfVATrAkSzb0VMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.17.5",
+        "@cspell/cspell-types": "8.18.1",
         "comment-json": "^4.2.5",
         "yaml": "^2.7.0"
       },
@@ -7872,15 +7868,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.17.5.tgz",
-      "integrity": "sha512-O/Uuhv1RuDu+5WYQml0surudweaTvr+2YJSmPSdlihByUSiogCbpGqwrRow7wQv/C5p1W1FlFjotvUfoR0fxHA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.18.1.tgz",
+      "integrity": "sha512-vKHEPSfkMKMR4S4tk6K2vHC+f3kdJK8Kdh/C0jDh6RRDjDsyAPxshtbremxOgAX6X8GaRUCROoMZ7FhB92+Y9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.5",
-        "@cspell/cspell-types": "8.17.5",
-        "cspell-trie-lib": "8.17.5",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "cspell-trie-lib": "8.18.1",
         "fast-equals": "^5.2.2"
       },
       "engines": {
@@ -7888,16 +7884,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.17.5.tgz",
-      "integrity": "sha512-I27fgOUZzH14jeIYo65LooB60fZ42f6OJL1lOR9Mk6IrIlDyUtzherGR+xx5KshK2katYkX42Qu4zsVYM6VFPA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.18.1.tgz",
+      "integrity": "sha512-gp/AdUtW6FqpKY4YyYJ3kz0OsXApwsV1FOUA9Z0VnOYKVZtt2snh4uNlI4Ltq+wh7pDU8mqaPWmX6Xy+HSRDkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.5",
-        "cspell-glob": "8.17.5",
-        "cspell-io": "8.17.5",
-        "find-up-simple": "^1.0.0"
+        "@cspell/url": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-io": "8.18.1"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -7907,13 +7902,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.17.5.tgz",
-      "integrity": "sha512-OXquou7UykInlGV5et5lNKYYrW0dwa28aEF995x1ocANND7o0bbHmFlbgyci/Lp4uFQai8sifmfFJbuIg2IC/A==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.18.1.tgz",
+      "integrity": "sha512-tlZXvzsN7dByHo69dz/HbJuQDUtrfhdioZ/LHaW7W9diG9NpaghgEfyX4fmsIXjU/2f66LDpYVY6osjtlOgyrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.5",
+        "@cspell/url": "8.18.1",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -7921,14 +7916,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.17.5.tgz",
-      "integrity": "sha512-st2n+FVw25MvMbsGb3TeJNRr6Oih4g14rjOd/UJN0qn+ceH360SAShUFqSd4kHHu2ADazI/TESFU6FRtMTPNOg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.18.1.tgz",
+      "integrity": "sha512-V6XTN1B++7EzJA0H4g4XbNJtqm6Y3/iXdLeZ6sMRDaNFKXXwTbWRtn8gukDQIytyw09AnCUKeqGSzCVqw26Omg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.5",
-        "@cspell/cspell-types": "8.17.5"
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -7938,42 +7933,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.17.5.tgz",
-      "integrity": "sha512-oevM/8l0s6nc1NCYPqNFumrW50QSHoa6wqUT8cWs09gtZdE2AWG0U6bIE8ZEVz6e6FxS+6IenGKTdUUwP0+3fg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.18.1.tgz",
+      "integrity": "sha512-mm9SUEF2yShuTXDSjCbsAqYTEb6jrtgcCnlqIzpsZOJOOe+zj/VyzTy2NJvOrdvR59dikdaqB75VGBMfHi804g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.17.5",
-        "@cspell/url": "8.17.5"
+        "@cspell/cspell-service-bus": "8.18.1",
+        "@cspell/url": "8.18.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.17.5.tgz",
-      "integrity": "sha512-S3KuOrcST1d2BYmTXA+hnbRdho5n3w5GUvEaCx3QZQBwAPfLpAwJbe2yig1TxBpyEJ5LqP02i/mDg1pUCOP0hQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.18.1.tgz",
+      "integrity": "sha512-t1j+XB7515yHmrczK6I1N6j0a72vmL/6OxsMJnCucHC6DO0WkOqmHulNRH7LpFacnns0dx15lmrAqPg7gQFcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.17.5",
-        "@cspell/cspell-pipe": "8.17.5",
-        "@cspell/cspell-resolver": "8.17.5",
-        "@cspell/cspell-types": "8.17.5",
-        "@cspell/dynamic-import": "8.17.5",
-        "@cspell/filetypes": "8.17.5",
-        "@cspell/strong-weak-map": "8.17.5",
-        "@cspell/url": "8.17.5",
+        "@cspell/cspell-bundled-dicts": "8.18.1",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-resolver": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "@cspell/dynamic-import": "8.18.1",
+        "@cspell/filetypes": "8.18.1",
+        "@cspell/strong-weak-map": "8.18.1",
+        "@cspell/url": "8.18.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.17.5",
-        "cspell-dictionary": "8.17.5",
-        "cspell-glob": "8.17.5",
-        "cspell-grammar": "8.17.5",
-        "cspell-io": "8.17.5",
-        "cspell-trie-lib": "8.17.5",
+        "cspell-config-lib": "8.18.1",
+        "cspell-dictionary": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-grammar": "8.18.1",
+        "cspell-io": "8.18.1",
+        "cspell-trie-lib": "8.18.1",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.2.2",
         "gensequence": "^7.0.0",
@@ -7988,14 +7983,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.17.5",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.17.5.tgz",
-      "integrity": "sha512-9hjI3nRQxtGEua6CgnLbK3sGHLx9dXR/BHwI/csRL4dN5GGRkE5X3CCoy1RJVL7iGFLIzi43+L10xeFRmWniKw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.18.1.tgz",
+      "integrity": "sha512-UaB36wsyp2eWeMtrbS6Q2t2WFvpedmGXJ879yHn9qKD7ViyUpI4cAbh6v7gWMUu+gjqCulXtke64k1ddmBihPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.5",
-        "@cspell/cspell-types": "8.17.5",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -8148,9 +8143,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
+      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8782,9 +8777,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.112",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
-      "integrity": "sha512-oen93kVyqSb3l+ziUgzIOlWt/oOuy4zRmpwestMn4rhFWAoFJeFuCVte9F2fASjeZZo7l/Cif9TiyrdW4CwEMA==",
+      "version": "1.5.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
+      "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9194,9 +9189,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
-      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9207,31 +9202,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.0",
-        "@esbuild/android-arm": "0.25.0",
-        "@esbuild/android-arm64": "0.25.0",
-        "@esbuild/android-x64": "0.25.0",
-        "@esbuild/darwin-arm64": "0.25.0",
-        "@esbuild/darwin-x64": "0.25.0",
-        "@esbuild/freebsd-arm64": "0.25.0",
-        "@esbuild/freebsd-x64": "0.25.0",
-        "@esbuild/linux-arm": "0.25.0",
-        "@esbuild/linux-arm64": "0.25.0",
-        "@esbuild/linux-ia32": "0.25.0",
-        "@esbuild/linux-loong64": "0.25.0",
-        "@esbuild/linux-mips64el": "0.25.0",
-        "@esbuild/linux-ppc64": "0.25.0",
-        "@esbuild/linux-riscv64": "0.25.0",
-        "@esbuild/linux-s390x": "0.25.0",
-        "@esbuild/linux-x64": "0.25.0",
-        "@esbuild/netbsd-arm64": "0.25.0",
-        "@esbuild/netbsd-x64": "0.25.0",
-        "@esbuild/openbsd-arm64": "0.25.0",
-        "@esbuild/openbsd-x64": "0.25.0",
-        "@esbuild/sunos-x64": "0.25.0",
-        "@esbuild/win32-arm64": "0.25.0",
-        "@esbuild/win32-ia32": "0.25.0",
-        "@esbuild/win32-x64": "0.25.0"
+        "@esbuild/aix-ppc64": "0.25.2",
+        "@esbuild/android-arm": "0.25.2",
+        "@esbuild/android-arm64": "0.25.2",
+        "@esbuild/android-x64": "0.25.2",
+        "@esbuild/darwin-arm64": "0.25.2",
+        "@esbuild/darwin-x64": "0.25.2",
+        "@esbuild/freebsd-arm64": "0.25.2",
+        "@esbuild/freebsd-x64": "0.25.2",
+        "@esbuild/linux-arm": "0.25.2",
+        "@esbuild/linux-arm64": "0.25.2",
+        "@esbuild/linux-ia32": "0.25.2",
+        "@esbuild/linux-loong64": "0.25.2",
+        "@esbuild/linux-mips64el": "0.25.2",
+        "@esbuild/linux-ppc64": "0.25.2",
+        "@esbuild/linux-riscv64": "0.25.2",
+        "@esbuild/linux-s390x": "0.25.2",
+        "@esbuild/linux-x64": "0.25.2",
+        "@esbuild/netbsd-arm64": "0.25.2",
+        "@esbuild/netbsd-x64": "0.25.2",
+        "@esbuild/openbsd-arm64": "0.25.2",
+        "@esbuild/openbsd-x64": "0.25.2",
+        "@esbuild/sunos-x64": "0.25.2",
+        "@esbuild/win32-arm64": "0.25.2",
+        "@esbuild/win32-ia32": "0.25.2",
+        "@esbuild/win32-x64": "0.25.2"
       }
     },
     "node_modules/esbuild-plugin-wasm": {
@@ -11746,9 +11741,9 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -11871,9 +11866,9 @@
       }
     },
     "node_modules/index-to-position": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
-      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11974,9 +11969,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.0.tgz",
-      "integrity": "sha512-J8FN1qM5nfrDo8sQKQwfj0+brTg1uBfZK2vY9hxci33lcl3BFrsELS9+1+4q/8tO1ASKfxZO8W3Pi2O4sVX2Lg==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.1.tgz",
+      "integrity": "sha512-gUeeX63EFgiaMgcs0cUs2ZUPvlOeEZ38okjK8twdWGZX2jYd2rCk8k/TJ3DSRIDZ2t/aZMv6I23guxHaofZE3w==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -11985,9 +11980,9 @@
       }
     },
     "node_modules/ipfs-unixfs-importer": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.3.1.tgz",
-      "integrity": "sha512-wHCTBqNsZXLJZ9/GSr7Msb3FDXD5yXF20Y9sKyUbbqNjbvaXs3n3h1+NM/5+WrgESHfwRcJIlJtaOKafL8Ymdg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.3.2.tgz",
+      "integrity": "sha512-12FqAAAE3YC6AHtYxZ944nDCabmvbNLdhNCVIN5RJIOri82ss62XdX4lsLpex9VvPzDIJyTAsrKJPcwM6hXGdQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -12963,16 +12958,16 @@
       }
     },
     "node_modules/it-all": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.6.tgz",
-      "integrity": "sha512-HXZWbxCgQZJfrv5rXvaVeaayXED8nTKx9tj9fpBhmcUJcedVZshMMMqTj0RG2+scGypb9Ut1zd1ifbf3lA8L+Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.7.tgz",
+      "integrity": "sha512-PkuYtu6XhJzuPTKXImd6y0qE6H91MUPV/b9xotXMAI6GjmD2v3NoHj2g5L0lS2qZ0EzyGWZU1kp0UxW8POvNBQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-batch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-3.0.6.tgz",
-      "integrity": "sha512-pQAAlSvJ4aV6xM/6LRvkPdKSKXxS4my2fGzNUxJyAQ8ccFdxPmK1bUuF5OoeUDkcdrbs8jtsmc4DypCMrGY6sg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-3.0.7.tgz",
+      "integrity": "sha512-tcAW8+OAnhC3WqO5ggInfndL/jJsL3i++JLBADKs7LSSzfVVOXicufAuY5Sv4RbCkulRuk/ClSZhS0fu9B9SJA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
@@ -12990,16 +12985,16 @@
       }
     },
     "node_modules/it-drain": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.7.tgz",
-      "integrity": "sha512-vy6S1JKjjHSIFHgBpLpD1zhkCRl3z1zYWUxE14+kAYf+BL9ssWSFImJfhl361IIcwr0ofw8etzg11VqqB+ntUA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.8.tgz",
+      "integrity": "sha512-eeOz+WwKc11ou1UuqZympcXPLCjpTn5ALcYFJiHeTEiYEZ2py/J1vq41XWYj88huCUiqp9iNHfObOKrbIk5Izw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-filter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.1.tgz",
-      "integrity": "sha512-TOXmVuaSkxlLp2hXKoMTra0WMZMKVFxE3vSsbIA+PbADNCBAHhjJ/lM31vBOUTddHMO34Ku++vU8T9PLlBxQtg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.2.tgz",
+      "integrity": "sha512-2AozaGjIvBBiB7t7MpVNug9kwofqmKSpvgW7zhuyvCs6xxDd6FrfvqyfYtlQTKLNP+Io1WeXko1UQhdlK4M0gg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13007,16 +13002,16 @@
       }
     },
     "node_modules/it-first": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.6.tgz",
-      "integrity": "sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.7.tgz",
+      "integrity": "sha512-e2dVSlOP+pAxPYPVJBF4fX7au8cvGfvLhIrGCMc5aWDnCvwgOo94xHbi3Da6eXQ2jPL5FGEM8sJMn5uE8Seu+g==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-foreach": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.1.tgz",
-      "integrity": "sha512-ID4Gxnavk/LVQLQESAQ9hR6dR63Ih6X+8VdxEktX8rpz2dCGAbZpey/eljTNbMfV2UKXHiu6UsneoNBZuac97g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.2.tgz",
+      "integrity": "sha512-PvXs3v1FaeWDhWzRxnwB4vSKJngxdLgi0PddkfurCvIFBmKTBfWONLeyDk5dxrvtCzdE4y96KzEQynk4/bbI5A==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13024,16 +13019,16 @@
       }
     },
     "node_modules/it-last": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.6.tgz",
-      "integrity": "sha512-M4/get95O85u2vWvWQinF8SJUc/RPC5bWTveBTYXvlP2q5TF9Y+QhT3nz+CRCyS2YEc66VJkyl/da6WrJ0wKhw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.7.tgz",
+      "integrity": "sha512-qG4BTveE6Wzsz5voqaOtZAfZgXTJT+yiaj45vp5S0Vi8oOdgKlRqUeolfvWoMCJ9vwSc/z9pAaNYIza7gA851w==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-length": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.6.tgz",
-      "integrity": "sha512-R7bxHAzpRzYz7vghc2DDH7x4KXvEkeLfN/h316++jzbkEHIRXbEPLbE20p5yrqqBdOeK6/FRUDuHlTJ0H1hysw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.7.tgz",
+      "integrity": "sha512-URrszwrzPrUn6PtsSFcixG4NwHydaARmPubO0UUnFH+NSNylBaGtair1fnxX7Zf2qVJQltPBVs3PZvcmFPTLXA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
@@ -13068,9 +13063,9 @@
       }
     },
     "node_modules/it-map": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.1.tgz",
-      "integrity": "sha512-9bCSwKD1yN1wCOgJ9UOl+46NQtdatosPWzxxUk2NdTLwRPXLh+L7iwCC9QKsbgM60RQxT/nH8bKMqm3H/o8IHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.2.tgz",
+      "integrity": "sha512-G3dzFUjTYHKumJJ8wa9dSDS3yKm8L7qDUnAgzemOD0UMztwm54Qc2v97SuUCiAgbOz/aibkSLImfoFK09RlSFQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13078,18 +13073,18 @@
       }
     },
     "node_modules/it-merge": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.5.tgz",
-      "integrity": "sha512-2l7+mPf85pyRF5pqi0dKcA54E5Jm/2FyY5GsOaN51Ta0ipC7YZ3szuAsH8wOoB6eKY4XsU4k2X+mzPmFBMayEA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.9.tgz",
+      "integrity": "sha512-TjY4WTiwe4ONmaKScNvHDAJj6Tw0UeQFp4JrtC/3Mq7DTyhytes7mnv5OpZV4gItpZcs0AgRntpT2vAy2cnXUw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-pushable": "^3.2.3"
+        "it-queueless-pushable": "^2.0.0"
       }
     },
     "node_modules/it-ndjson": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.1.tgz",
-      "integrity": "sha512-BnrucXWzX5xz1SDo5B4ayVqQ+Qa0LKsuXiOiVidqaT7hvEqi/qIi8teCTSa9m81V7dADrVKjpWvqvWDvmf30mA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.2.tgz",
+      "integrity": "sha512-TPKpdYSNKjDdroCPnLamM5Up6XnPQ7F1KgNP3Ib5y5O4ayOVP+DHac/pzjUigcg9Kf9gkGVXDz8+FFKpWwoB3w==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13111,9 +13106,9 @@
       }
     },
     "node_modules/it-parallel": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.8.tgz",
-      "integrity": "sha512-URLhs6eG4Hdr4OdvgBBPDzOjBeSSmI+Kqex2rv/aAyYClME26RYHirLVhZsZP5M+ZP6M34iRlXk8Wlqtezuqpg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.9.tgz",
+      "integrity": "sha512-FSg8T+pr7Z1VUuBxEzAAp/K1j8r1e9mOcyzpWMxN3mt33WFhroFjWXV1oYSSjNqcdYwxD/XgydMVMktJvKiDog==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13121,9 +13116,9 @@
       }
     },
     "node_modules/it-parallel-batch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-3.0.6.tgz",
-      "integrity": "sha512-3wgiQGvMMHy65OXScrtrtmY+bJSF7P6St1AP+BU+SK83fEr8NNk/MrmJKrtB1+MahYX2a8I+pOGKDj8qVtuV0Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-3.0.7.tgz",
+      "integrity": "sha512-R/YKQMefUwLYfJ2UxMaxQUf+Zu9TM+X1KFDe4UaSQlcNog6AbMNMBt3w1suvLEjDDMrI9FNrlopVumfBIboeOg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13131,9 +13126,9 @@
       }
     },
     "node_modules/it-peekable": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.5.tgz",
-      "integrity": "sha512-JWQOGMt6rKiPcY30zUVMR4g6YxkpueTwHVE7CMs/aGqCf4OydM6w+7ZM3PvmO1e0TocjuR4aL8xyZWR46cTqCQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.6.tgz",
+      "integrity": "sha512-odk9wn8AwFQipy8+tFaZNRCM62riraKZJRysfbmOett9wgJumCwgZFzWUBUwMoiQapEcEVGwjDpMChZIi+zLuQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
@@ -13153,14 +13148,14 @@
       }
     },
     "node_modules/it-protobuf-stream": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.5.tgz",
-      "integrity": "sha512-H70idW45As3cEbU4uSoZ9IYHUIV3YM69/2mmXYR7gOlPabWjuyNi3/abK11geiiq3la27Sos/mXr68JljjKtEQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.6.tgz",
+      "integrity": "sha512-TxqgDHXTBt1XkYhrGKP8ubNsYD4zuTClSg6S1M0xTPsskGKA4nPFOGM60zrkh4NMB1Wt3EnsqM5U7kXkx60EXQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-length-prefixed-stream": "^1.0.0",
-        "it-stream-types": "^2.0.1",
+        "it-stream-types": "^2.0.2",
         "uint8arraylist": "^2.4.8"
       }
     },
@@ -13235,9 +13230,9 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.6.tgz",
-      "integrity": "sha512-aNrlZAXB8vWBd42tCpaXGL6CJVJNDW3OLczmdt6g0k/s9Z6evkTdgU2LjwW5SNNeX41sF+C8MjV+OcVf93PsPw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.7.tgz",
+      "integrity": "sha512-PsaKSd2Z0uhq8Mq5htdfsE/UagmdLCLWdBXPwi3FZGR4BTG180pFamhK+O+luFtBCNGRoqKAdtbZGTyGwA9uzw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13251,20 +13246,20 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-take": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.6.tgz",
-      "integrity": "sha512-uqw3MRzf9to1SOLxaureGa73lK8k8ZB/asOApTAkvrzUqCznGtKNgPFH7uYIWlt4UuWq/hU6I+U4Fm5xpjN8Vg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.7.tgz",
+      "integrity": "sha512-0+EbsTvH1XCpwhhFkjWdqJTjzS5XP3KL69woBqwANNhMLKn0j39jk/WHIlvbg9XW2vEm7cZz4p8w5DkBZR8LoA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-to-buffer": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-4.0.7.tgz",
-      "integrity": "sha512-c7JXrFg8xntJTPzhg7Dg6WJYm+XW0wBUebvEBrc6zrL/QukGRXclw1OBz6M9Qmqkiorgb3qpsRwKlI/4Q3tmkQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-4.0.8.tgz",
+      "integrity": "sha512-niZbR/+GbyQ2F2Nj79EJprT0gji5Si4nM1eJpgtlvfbvhsi5ZgA/y+mzSrOoNajiTC3svqvoNy8HGlTW2Faz/A==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "uint8arrays": "^5.0.3"
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/jackspeak": {
@@ -13560,9 +13555,9 @@
       }
     },
     "node_modules/ky": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-1.7.5.tgz",
-      "integrity": "sha512-HzhziW6sc5m0pwi5M196+7cEBtbt0lCYi67wNsiwMUmz833wloE0gbzJPWKs1gliFKQb34huItDQX97LyOdPdA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.8.1.tgz",
+      "integrity": "sha512-7Bp3TpsE+L+TARSnnDpk3xg8Idi8RwSLdj6CMbNWoOARIrGrbuLGusV0dYwbZOm4bB3jHNxSw8Wk/ByDqJEnDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13603,30 +13598,30 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.8.0.tgz",
-      "integrity": "sha512-z8BjC3FmzV1WBkKSoJbN5OIyeTu6J5ocNOg4+83KHHYB6n2ICf3N90+pGMNm5B0t2ETJ0urhXZkuZSt7y+4kww==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.8.4.tgz",
+      "integrity": "sha512-NGsbZ8MQFpuiZKP57hn8qe4QZ7r1j6LTlGx4m3FAVurPtyWHpZ702sWrqpFJveXAYl17Lk7OOA0r08T0k0SS2g==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/interface-internal": "^2.3.7",
-        "@libp2p/logger": "^5.1.12",
-        "@libp2p/multistream-select": "^6.0.19",
-        "@libp2p/peer-collections": "^6.0.23",
-        "@libp2p/peer-id": "^5.0.16",
-        "@libp2p/peer-store": "^11.1.0",
-        "@libp2p/utils": "^6.5.7",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/logger": "^5.1.15",
+        "@libp2p/multistream-select": "^6.0.22",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-store": "^11.1.4",
+        "@libp2p/utils": "^6.6.2",
         "@multiformats/dns": "^1.0.6",
         "@multiformats/multiaddr": "^12.3.5",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@multiformats/multiaddr-matcher": "^1.7.0",
         "any-signal": "^4.1.1",
         "datastore-core": "^10.0.2",
         "interface-datastore": "^8.3.1",
-        "it-byte-stream": "^1.1.0",
+        "it-byte-stream": "^2.0.1",
         "it-merge": "^3.0.5",
         "it-parallel": "^3.0.8",
         "merge-options": "^3.0.4",
@@ -13637,29 +13632,6 @@
         "race-event": "^1.3.0",
         "race-signal": "^1.1.2",
         "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/it-byte-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
-      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-queueless-pushable": "^1.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/libp2p/node_modules/it-queueless-pushable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
-      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.1",
-        "race-signal": "^1.1.3"
       }
     },
     "node_modules/lilconfig": {
@@ -15349,9 +15321,9 @@
       }
     },
     "node_modules/mime": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
-      "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
+      "integrity": "sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa"
@@ -15781,9 +15753,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
-      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "dev": true,
       "funding": [
         {
@@ -21550,9 +21522,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -21714,9 +21686,9 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
+      "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -22808,15 +22780,15 @@
       }
     },
     "node_modules/read-pkg/node_modules/parse-json": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
-      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "index-to-position": "^0.1.2",
-        "type-fest": "^4.7.1"
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
       },
       "engines": {
         "node": ">=18"
@@ -23311,9 +23283,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -24001,9 +23973,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.2.tgz",
-      "integrity": "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -24450,17 +24422,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/fake-timers": "^13.0.5",
         "@sinonjs/samsam": "^8.0.1",
         "diff": "^7.0.0",
-        "nise": "^6.1.1",
         "supports-color": "^7.2.0"
       },
       "funding": {
@@ -24494,9 +24465,9 @@
       }
     },
     "node_modules/sirv/node_modules/@polka/url": {
-      "version": "1.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
     },
@@ -25786,9 +25757,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
-      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -26289,9 +26260,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -26834,16 +26805,17 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -27086,9 +27058,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -27213,9 +27185,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^1.0.0",
     "@libp2p/crypto": "^5.0.0",
-    "@libp2p/interface": "^2.0.0",
+    "@libp2p/interface": "^2.9.0",
     "@libp2p/peer-id": "^5.0.0",
     "@noble/ciphers": "^1.1.3",
     "@noble/curves": "^1.1.0",
@@ -194,7 +194,7 @@
     "multiformats": "^13.2.2",
     "p-defer": "^4.0.0",
     "protons": "^7.6.0",
-    "sinon": "^19.0.2",
+    "sinon": "^20.0.0",
     "sinon-ts": "^2.0.0"
   },
   "browser": {

--- a/test/muxers.spec.ts
+++ b/test/muxers.spec.ts
@@ -1,0 +1,167 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import { duplexPair } from 'it-pair/duplex'
+import { stubInterface, type StubbedInstance } from 'sinon-ts'
+import { Noise } from '../src/noise.js'
+import { createPeerIdsFromFixtures } from './fixtures/peer.js'
+import type { StreamMuxerFactory, Upgrader, SecureConnectionOptions, SecuredConnection, PeerId, PrivateKey } from '@libp2p/interface'
+import type { Uint8ArrayList } from 'uint8arraylist'
+
+describe('early muxer selection', () => {
+  let initUpgrader: StubbedInstance<Upgrader>
+  let respUpgrader: StubbedInstance<Upgrader>
+  let remotePeer: { peerId: PeerId, privateKey: PrivateKey }
+  let localPeer: { peerId: PeerId, privateKey: PrivateKey }
+
+  beforeEach(async () => {
+    [localPeer, remotePeer] = await createPeerIdsFromFixtures(2)
+
+    initUpgrader = stubInterface<Upgrader>()
+    respUpgrader = stubInterface<Upgrader>()
+  })
+
+  async function testMuxerNegotiation (outboundOpts?: SecureConnectionOptions, inboundOpts?: SecureConnectionOptions): Promise<[SecuredConnection, SecuredConnection]> {
+    const noiseInit = new Noise({
+      ...localPeer,
+      logger: defaultLogger(),
+      upgrader: initUpgrader
+    })
+    const noiseResp = new Noise({
+      ...remotePeer,
+      logger: defaultLogger(),
+      upgrader: respUpgrader
+    })
+
+    const [inboundConnection, outboundConnection] = duplexPair<Uint8Array | Uint8ArrayList>()
+
+    return Promise.all([
+      noiseInit.secureOutbound(outboundConnection, {
+        remotePeer: remotePeer.peerId,
+        ...inboundOpts
+      }),
+      noiseResp.secureInbound(inboundConnection, {
+        remotePeer: localPeer.peerId,
+        ...outboundOpts
+      })
+    ])
+  }
+
+  it('should negotiate early stream muxer', async () => {
+    const commonMuxer = '/common/muxer'
+
+    initUpgrader.getStreamMuxers.returns(new Map([
+      ['/other/muxer', stubInterface<StreamMuxerFactory>()],
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })]
+    ]))
+    respUpgrader.getStreamMuxers.returns(new Map([
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })],
+      ['/another/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+
+    const [securedInbound, securedOutbound] = await testMuxerNegotiation()
+
+    expect(securedInbound).to.have.nested.property('streamMuxer.protocol', commonMuxer)
+    expect(securedOutbound).to.have.nested.property('streamMuxer.protocol', commonMuxer)
+  })
+
+  it('should fail to negotiate early muxer when there are no common muxers', async () => {
+    initUpgrader.getStreamMuxers.returns(new Map([
+      ['/other/muxer', stubInterface<StreamMuxerFactory>()],
+      ['/yet/other/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+    respUpgrader.getStreamMuxers.returns(new Map([
+      ['/another/muxer', stubInterface<StreamMuxerFactory>()],
+      ['/yet/another/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+
+    await expect(testMuxerNegotiation()).to.eventually.be.rejectedWith(/no common muxers/)
+  })
+
+  it('should not negotiate early muxer when no muxers are sent', async () => {
+    initUpgrader.getStreamMuxers.returns(new Map([]))
+    respUpgrader.getStreamMuxers.returns(new Map([]))
+
+    const [securedInbound, securedOutbound] = await testMuxerNegotiation()
+
+    expect(securedInbound).to.have.property('streamMuxer', undefined)
+    expect(securedOutbound).to.have.property('streamMuxer', undefined)
+  })
+
+  it('should skip selecting stream muxers', async () => {
+    const commonMuxer = '/common/muxer'
+
+    initUpgrader.getStreamMuxers.returns(new Map([
+      ['/other/muxer', stubInterface<StreamMuxerFactory>()],
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })]
+    ]))
+    respUpgrader.getStreamMuxers.returns(new Map([
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })],
+      ['/another/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+
+    const [securedInbound, securedOutbound] = await testMuxerNegotiation({
+      skipStreamMuxerNegotiation: true
+    }, {
+      skipStreamMuxerNegotiation: true
+    })
+
+    expect(securedInbound).to.have.property('streamMuxer', undefined)
+    expect(securedOutbound).to.have.property('streamMuxer', undefined)
+  })
+
+  it('should not select muxer if only initiator requires it', async () => {
+    const commonMuxer = '/common/muxer'
+
+    initUpgrader.getStreamMuxers.returns(new Map([
+      ['/other/muxer', stubInterface<StreamMuxerFactory>()],
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })]
+    ]))
+    respUpgrader.getStreamMuxers.returns(new Map([
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })],
+      ['/another/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+
+    const [securedInbound, securedOutbound] = await testMuxerNegotiation({
+      skipStreamMuxerNegotiation: true
+    })
+
+    expect(securedInbound).to.have.property('streamMuxer', undefined)
+    expect(securedOutbound).to.have.property('streamMuxer', undefined)
+  })
+
+  it('should not select muxer if only responder requires it', async () => {
+    const commonMuxer = '/common/muxer'
+
+    initUpgrader.getStreamMuxers.returns(new Map([
+      ['/other/muxer', stubInterface<StreamMuxerFactory>()],
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })]
+    ]))
+    respUpgrader.getStreamMuxers.returns(new Map([
+      [commonMuxer, stubInterface<StreamMuxerFactory>({
+        protocol: commonMuxer
+      })],
+      ['/another/muxer', stubInterface<StreamMuxerFactory>()]
+    ]))
+
+    const [securedInbound, securedOutbound] = await testMuxerNegotiation({}, {
+      skipStreamMuxerNegotiation: true
+    })
+
+    expect(securedInbound).to.have.property('streamMuxer', undefined)
+    expect(securedOutbound).to.have.property('streamMuxer', undefined)
+  })
+})

--- a/test/noise.spec.ts
+++ b/test/noise.spec.ts
@@ -235,39 +235,6 @@ describe('Noise', () => {
     }
   })
 
-  it('should fail to accept early muxer from remote peer', async () => {
-    const streamMuxerProtocol = '/my-early-muxer'
-    const otherStreamMuxerProtocol = '/my-other-early-muxer'
-    const staticKeysInitiator = pureJsCrypto.generateX25519KeyPair()
-    const noiseInit = new Noise({
-      ...localPeer,
-      logger: defaultLogger(),
-      upgrader: stubInterface<Upgrader>({
-        getStreamMuxers: () => new Map([[streamMuxerProtocol, stubInterface<StreamMuxerFactory>({
-          protocol: streamMuxerProtocol
-        })]])
-      })
-    }, { staticNoiseKey: staticKeysInitiator.privateKey })
-    const staticKeysResponder = pureJsCrypto.generateX25519KeyPair()
-    const noiseResp = new Noise({
-      ...remotePeer,
-      logger: defaultLogger(),
-      upgrader: stubInterface<Upgrader>({
-        getStreamMuxers: () => new Map([[otherStreamMuxerProtocol, stubInterface<StreamMuxerFactory>({
-          protocol: otherStreamMuxerProtocol
-        })]])
-      })
-    }, { staticNoiseKey: staticKeysResponder.privateKey })
-
-    const [inboundConnection, outboundConnection] = duplexPair<Uint8Array | Uint8ArrayList>()
-    await expect(Promise.all([
-      noiseInit.secureOutbound(outboundConnection, {
-        remotePeer: remotePeer.peerId
-      }),
-      noiseResp.secureInbound(inboundConnection)
-    ])).to.eventually.be.rejectedWith(/no common muxers/)
-  })
-
   it('should accept a prologue', async () => {
     try {
       const noiseInit = new Noise({


### PR DESCRIPTION
Allows transports such as WebRTC-Direct to skip the early muxer negotiation.

This handles an edge case where you have a libp2p node configured with no dedicated muxer(s), instead transport(s) that incorporate their own muxers but that use Noise to exchange PeerIDs.

Splits the existing muxer negotiation test out into it's own file and adds more tests to handle the various configurations.