### PR TITLE
fix: upate typesversions and typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,22 @@
   ],
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,7 @@
 {
   "readme": "none",
   "entryPoints": [
-    "./src/index.ts"
+    "./src/index.ts",
+    "./src/crypto/index.ts"
   ]
 }


### PR DESCRIPTION
Ensure that the new export can be used with older typescript versions and that it is included in the documentation.